### PR TITLE
Update multiselect hash to require key names

### DIFF
--- a/jmespath/ast.py
+++ b/jmespath/ast.py
@@ -1,9 +1,5 @@
 class AST(object):
     VALUE_METHODS = []
-    # This can be override on a per instance level.
-    # The parser can set this attribute to tell the node what part of the input
-    # text is associated with this particular node.
-    ASSOCIATED_TEXT = ''
 
     def search(self, value):
         pass
@@ -63,7 +59,6 @@ class Field(AST):
 
     def __init__(self, name):
         self.name = name
-        self.ASSOCIATED_TEXT = name
 
     def pretty_print(self, indent=''):
         return "%sField(%s)" % (indent, self.name)
@@ -97,8 +92,7 @@ class MultiFieldDict(BaseMultiField):
     def _multi_get(self, value):
         collected = {}
         for node in self.nodes:
-            key_name = node.ASSOCIATED_TEXT
-            collected[key_name] = node.search(value)
+            collected[node.key_name] = node.search(value)
         return collected
 
 
@@ -110,6 +104,19 @@ class MultiFieldList(BaseMultiField):
         for node in self.nodes:
             collected.append(node.search(value))
         return collected
+
+
+class KeyValPair(AST):
+    def __init__(self, key_name, node):
+        self.key_name = key_name
+        self.node = node
+
+    def search(self, value):
+        return self.node.search(value)
+
+    def pretty_print(self, indent=''):
+        return "%sKeyValPair(key_name=%s, node=%s)" % (indent, self.key_name,
+                                                       self.node)
 
 
 class Index(AST):
@@ -199,8 +206,7 @@ class _MultiMatch(list):
             else:
                 result = {}
                 for node in nodes:
-                    key_name = node.ASSOCIATED_TEXT
-                    result[key_name] = node.search(element)
+                    result[node.key_name] = node.search(element)
             results.append(result)
         return results
 

--- a/jmespath/lexer.py
+++ b/jmespath/lexer.py
@@ -14,6 +14,7 @@ class LexerDefinition(object):
         'NUMBER',
         'IDENTIFIER',
         'COMMA',
+        'COLON',
     ) + tuple(reserved.values())
 
     t_STAR = r'\*'
@@ -24,6 +25,7 @@ class LexerDefinition(object):
     t_RBRACE = r'\}'
     t_OR = r'\|\|'
     t_COMMA = r','
+    t_COLON = r':'
     t_ignore = ' '
 
     def t_NUMBER(self, t):
@@ -32,7 +34,7 @@ class LexerDefinition(object):
         return t
 
     def t_IDENTIFIER(self, t):
-        r'(([a-zA-Z_][a-zA-Z_0-9]*)|("(\"|.)*"))'
+        r'(([a-zA-Z_][a-zA-Z_0-9]*)|("(?:\\"|[^"])*"))'
         t.type = self.reserved.get(t.value, 'IDENTIFIER')
         i = 0
         if t.value[0] == '"' and t.value[-1] == '"':

--- a/tests/compliance/escape.json
+++ b/tests/compliance/escape.json
@@ -6,7 +6,8 @@
         "foo\"bar": "doublequote",
         "c:\\\\windows\\path": "windows",
         "/unix/path": "unix",
-        "\"\"\"": "threequotes"
+        "\"\"\"": "threequotes",
+        "bar": {"baz": "qux"}
      },
      "cases": [
          {
@@ -36,6 +37,10 @@
          {
             "expression": "\"\\\"\\\"\\\"\"",
             "result": "threequotes"
+         },
+         {
+            "expression": "\"bar\".\"baz\"",
+            "result": "qux"
          }
      ]
 }]

--- a/tests/compliance/multiselect.json
+++ b/tests/compliance/multiselect.json
@@ -23,61 +23,86 @@
         }
       },
       "bar": 1,
-      "baz": 2
+      "baz": 2,
+      "qux\"": 3
     },
      "cases": [
          {
-            "expression": "foo.{bar}",
+            "expression": "foo.{bar: bar}",
             "result": {"bar": "bar"}
          },
          {
-            "expression": "foo.{bar,baz}",
+            "expression": "foo.{\"bar\": bar}",
+            "result": {"bar": "bar"}
+         },
+         {
+            "expression": "foo.{\"foo.bar\": bar}",
+            "result": {"foo.bar": "bar"}
+         },
+         {
+            "expression": "foo.{bar: bar, baz: baz}",
             "result": {"bar": "bar", "baz": "baz"}
          },
          {
-            "expression": "foo.{bar,qux}",
+            "expression": "foo.{\"bar\": bar, \"baz\": baz}",
+            "result": {"bar": "bar", "baz": "baz"}
+         },
+         {
+            "expression": "{\"baz\": baz, \"qux\\\"\": \"qux\\\"\"}",
+            "result": {"baz": 2, "qux\"": 3}
+         },
+         {
+            "expression": "foo.{bar:bar,baz:baz}",
+            "result": {"bar": "bar", "baz": "baz"}
+         },
+         {
+            "expression": "foo.{bar: bar,qux: qux}",
             "result": {"bar": "bar", "qux": "qux"}
          },
          {
-            "expression": "foo.{bar,noexist}",
+            "expression": "foo.{bar: bar, noexist: noexist}",
             "result": {"bar": "bar", "noexist": null}
          },
          {
-            "expression": "foo.{noexist,alsonoexist}",
+            "expression": "foo.{noexist: noexist, alsonoexist: alsonoexist}",
             "result": {"noexist": null, "alsonoexist": null}
          },
          {
-            "expression": "foo.badkey.{nokey,alsonokey}",
+            "expression": "foo.badkey.{nokey: nokey, alsonokey: alsonokey}",
             "result": null
          },
          {
-            "expression": "foo.nested.*.{a,b}",
+            "expression": "foo.nested.*.{a: a,b: b}",
             "result": [{"a": "first", "b": "second"},
                        {"a": "first", "b": "second"},
                        {"a": "first", "b": "second"}]
          },
          {
-            "expression": "foo.nested.three.{a,c.inner}",
-            "result": {"a": "first", "c.inner": "third"}
+            "expression": "foo.nested.three.{a: a, cinner: c.inner}",
+            "result": {"a": "first", "cinner": "third"}
          },
          {
-            "expression": "foo.nested.three.{a,c.inner.bad.key}",
-            "result": {"a": "first", "c.inner.bad.key": null}
+            "expression": "foo.nested.three.{a: a, c: c.inner.bad.key}",
+            "result": {"a": "first", "c": null}
          },
          {
-            "expression": "foo.{nested.one.a,nested.two.b}",
-            "result": {"nested.one.a": "first", "nested.two.b": "second"}
+            "expression": "foo.{a: nested.one.a, b: nested.two.b}",
+            "result": {"a": "first", "b": "second"}
          },
          {
-            "expression": "{bar,baz}",
+            "expression": "{bar: bar, baz: baz}",
             "result": {"bar": 1, "baz": 2}
          },
          {
-            "expression": "{bar}",
+            "expression": "{bar: bar}",
             "result": {"bar": 1}
          },
          {
-            "expression": "{no,exist}",
+            "expression": "{otherkey: bar}",
+            "result": {"otherkey": 1}
+         },
+         {
+            "expression": "{no: no, exist: exist}",
             "result": {"no": null, "exist": null}
          },
          {
@@ -107,7 +132,7 @@
     },
     "cases": [
          {
-            "expression": "foo.{bar,baz}",
+            "expression": "foo.{bar:bar,baz:baz}",
             "result": {"bar": 1, "baz": [2, 3, 4]}
          },
          {
@@ -137,7 +162,7 @@
     },
     "cases": [
          {
-            "expression": "foo.{bar,baz}",
+            "expression": "foo.{bar: bar, baz: baz}",
             "result": {"bar": 1, "baz": 2}
          },
          {
@@ -155,12 +180,12 @@
     },
     "cases": [
          {
-            "expression": "foo.{bar.baz[1],includeme}",
-            "result": {"bar.baz[1]": {"two": 2}, "includeme": true}
+            "expression": "foo.{bar: bar.baz[1],includeme: includeme}",
+            "result": {"bar": {"two": 2}, "includeme": true}
          },
          {
-            "expression": "foo.{bar.baz[1].two,includeme}",
-            "result": {"bar.baz[1].two": 2, "includeme": true}
+            "expression": "foo.{\"bar.baz.two\": bar.baz[1].two, includeme: includeme}",
+            "result": {"bar.baz.two": 2, "includeme": true}
          }
     ]
 }, {
@@ -181,7 +206,7 @@
       ]},
     "cases": [
          {
-            "expression": "reservations[*].instances[*].{id,name}",
+            "expression": "reservations[*].instances[*].{id: id, name: name}",
             "result": [[{"id": "id1", "name": "first"}, {"id": "id2", "name": "second"}],
                        [{"id": "id3", "name": "third"}, {"id": "id4", "name": "fourth"}]]
          }

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -157,14 +157,21 @@ class TestAST(unittest.TestCase):
 
     def test_multiselect_dict(self):
         # foo.{bar,baz}
-        field_foo = ast.Field('foo')
-        field_bar = ast.Field('bar')
-        field_baz = ast.Field('baz')
+        field_foo = ast.KeyValPair(key_name='foo', node=ast.Field('foo'))
+        field_bar = ast.KeyValPair(key_name='bar', node=ast.Field('bar'))
+        field_baz = ast.KeyValPair(key_name='baz', node=ast.Field('baz'))
         multiselect = ast.MultiFieldDict([field_bar, field_baz])
         subexpr = ast.SubExpression(field_foo, multiselect)
         self.assertEqual(
             subexpr.search({'foo': {'bar': 1, 'baz': 2, 'qux': 3}}),
             {'bar': 1, 'baz': 2})
+
+    def test_multiselect_different_key_names(self):
+        field_foo = ast.KeyValPair(key_name='arbitrary', node=ast.Field('foo'))
+        field_bar = ast.KeyValPair(key_name='arbitrary2', node=ast.Field('bar'))
+        multiselect = ast.MultiFieldDict([field_foo, field_bar])
+        self.assertEqual(multiselect.search({'foo': 'value1', 'bar': 'value2'}),
+                         {'arbitrary': 'value1', 'arbitrary2': 'value2'})
 
     def test_multiselect_list(self):
         # foo.[bar,baz]


### PR DESCRIPTION
Instead of "{foo,bar}" you need to say "{foo: foo, bar: bar}".
This makes it easier when you have more complicated non branched
expressions, for example:
"{foo: foo.bar.baz[0], first_state: states[0].name}"

This also exposed a bug in the lexer regarding double quoted identifiers and being able to escape quoted identifiers.  I've added additional tests to capture this bug.

cc @garnaat @mtdowling
