### PR TITLE
Fix issue 18, indexing wildcard projections

### DIFF
--- a/jmespath/ast.py
+++ b/jmespath/ast.py
@@ -219,8 +219,7 @@ class _Projection(list):
                 matches.append(el[index])
             except (IndexError, TypeError):
                 pass
-        if matches:
-            return self.__class__(matches)
+        return self.__class__(matches)
 
     def multi_get(self, nodes):
         results = self.__class__([])

--- a/tests/compliance/indices.json
+++ b/tests/compliance/indices.json
@@ -216,6 +216,11 @@
      },
     "cases": [
         {
+           "expression": "foo[]",
+           "result": [["one", "two"], ["three", "four"], ["five", "six"],
+                      ["seven", "eight"], ["nine"], ["ten"]]
+        },
+        {
            "expression": "foo[][0]",
            "result": ["one", "three", "five", "seven", "nine", "ten"]
         },
@@ -225,15 +230,15 @@
         },
         {
            "expression": "foo[][0][0]",
-           "result": null
+           "result": []
         },
          {
             "expression": "foo[][2][2]",
-            "result": null
+            "result": []
          },
          {
             "expression": "foo[][0][0][100]",
-            "result": null
+            "result": []
          }
     ]
 },

--- a/tests/compliance/wildcard.json
+++ b/tests/compliance/wildcard.json
@@ -140,7 +140,7 @@
          },
          {
             "expression": "foo.bar[*].baz[3]",
-            "result": null
+            "result": []
          }
      ]
 },
@@ -212,7 +212,7 @@
          },
          {
             "expression": "foo[*].bar[2]",
-            "result": null
+            "result": []
          }
      ]
 },
@@ -223,7 +223,7 @@
      "cases": [
          {
             "expression": "foo[*].bar[0]",
-            "result": null
+            "result": []
          }
      ]
 },
@@ -251,7 +251,8 @@
                 ["five", "six"], ["seven", "eight"]
             ], [
                 ["nine"], ["ten"]
-        ]]
+            ]
+        ]
      },
      "cases": [
          {
@@ -279,8 +280,12 @@
             "result": ["four", "eight"]
          },
          {
+            "expression": "foo[*][2]",
+            "result": []
+         },
+         {
             "expression": "foo[*][2][2]",
-            "result": null
+            "result": []
          }
      ]
 }

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -207,7 +207,7 @@ class TestAST(unittest.TestCase):
             ast.WildcardValues(),
             ast.SubExpression(ast.Field("foo"), ast.Index(0)))
         data = {"a": {"foo": 1}, "b": {"foo": 1}, "c": {"bar": 1}}
-        self.assertEqual(parsed.search(data), None)
+        self.assertEqual(parsed.search(data), [])
 
     def test_wildcard_values_index_does_exist(self):
         parsed = ast.SubExpression(


### PR DESCRIPTION
This should always return a list per projection.
Projections apply to both the wildcard operator `[*]`
as well as the flattening operator `[]`.

cc @mtdowling
