### PR TITLE
Allow wildcard projections on wildcards

### DIFF
--- a/jmespath/ast.py
+++ b/jmespath/ast.py
@@ -246,6 +246,16 @@ class _Projection(list):
             results.append(result)
         return results
 
+    def values(self):
+        results = self.__class__([])
+        for element in self:
+            try:
+                current = self.__class__(element.values())
+                results.append(current)
+            except AttributeError:
+                continue
+        return results
+
 
 class ORExpression(AST):
     def __init__(self, first, remaining):

--- a/tests/compliance/wildcard.json
+++ b/tests/compliance/wildcard.json
@@ -15,6 +15,13 @@
             },
             "other4": {
                 "notbaz": ["d", "e", "f"]
+            },
+            "other5": {
+                "other": {
+                    "a": 1,
+                    "b": 2,
+                    "c": 3
+                }
             }
         }
     },
@@ -41,19 +48,23 @@
          },
          {
             "expression": "foo.*",
-            "result": [{"baz": "one"}, {"baz": "two"}, {"baz": "three"}, {"notbaz": ["a", "b", "c"]}, {"notbaz": ["d", "e", "f"]}]
+            "result": [{"baz": "one"}, {"baz": "two"}, {"baz": "three"},
+                       {"notbaz": ["a", "b", "c"]}, {"notbaz": ["d", "e", "f"]},
+                       {"other": {"a": 1, "b": 2, "c": 3}}]
          },
          {
             "expression": "foo.*.*",
-            "result": null
+            "result": [["one"], ["two"], ["three"],
+                       [["a", "b", "c"]], [["d", "e", "f"]],
+                       [{"a": 1, "b": 2, "c": 3}]]
          },
          {
             "expression": "foo.*.*.*",
-            "result": null
+            "result": [[], [], [], [], [], [[1, 2, 3]]]
          },
          {
             "expression": "foo.*.*.*.*",
-            "result": null
+            "result": [[], [], [], [], [], [[]]]
          }
     ]
 }, {
@@ -88,8 +99,25 @@
     },
     "cases": [
          {
+            "expression": "*",
+            "result": [{"sub1": {"foo": "one"}},
+                       {"sub1": {"foo": "two"}},
+                       { "sub3": {"notfoo": "notfoo"}}]
+         },
+         {
+            "expression": "*.sub1",
+            "result": [{"foo": "one"},
+                       {"foo": "two"}]
+         },
+         {
+            "expression": "*.*",
+            "result": [[{"foo": "one"}],
+                       [{"foo": "two"}],
+                       [{"notfoo": "notfoo"}]]
+         },
+         {
             "expression": "*.*.foo",
-            "result": null
+            "result": [["one"], ["two"], []]
          },
          {
             "expression": "*.sub1.foo",


### PR DESCRIPTION
Support `'*.*'`.  Fixes #19.

cc @mtdowling
