### PR TITLE
Fix wildcard projection bug

### DIFF
--- a/jmespath/ast.py
+++ b/jmespath/ast.py
@@ -150,8 +150,8 @@ class WildcardIndex(AST):
 
     """
     def search(self, value):
-        if value is None:
-            value = []
+        if not isinstance(value, list):
+            return None
         return _Projection(value)
 
     def pretty_print(self, indent=''):

--- a/tests/compliance/wildcard.json
+++ b/tests/compliance/wildcard.json
@@ -317,11 +317,57 @@
          },
          {
             "expression": "bar[*]",
-            "result": []
+            "result": null
          },
          {
             "expression": "bar[*].baz[*]",
-            "result": []
+            "result": null
+         }
+     ]
+},
+{
+    "given": {
+        "string": "string",
+        "hash": {"foo": "bar", "bar": "baz"},
+        "number": 23,
+        "nullvalue": null
+     },
+     "cases": [
+         {
+            "expression": "string[*]",
+            "result": null
+         },
+         {
+            "expression": "hash[*]",
+            "result": null
+         },
+         {
+            "expression": "number[*]",
+            "result": null
+         },
+         {
+            "expression": "nullvalue[*]",
+            "result": null
+         },
+         {
+            "expression": "string[*].foo",
+            "result": null
+         },
+         {
+            "expression": "hash[*].foo",
+            "result": null
+         },
+         {
+            "expression": "number[*].foo",
+            "result": null
+         },
+         {
+            "expression": "nullvalue[*].foo",
+            "result": null
+         },
+         {
+            "expression": "nullvalue[*].foo[*].bar",
+            "result": null
          }
      ]
 }


### PR DESCRIPTION
Don't project a None (null) value, project
an empty list if we receive a None value.

This was previously generating an uncaught exception because we try to extend a list with a `None` value.
