### PR TITLE
Implement JEP 1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,12 +50,9 @@ The grammar is specified using ABNF, as described in `RFC4234`_
     sub-expression    = expression "." expression
     or-expression     = expression "||" expression
     index-expression  = expression bracket-specifier / bracket-specifier
-    multi-select-list = "[" ( non-branched-expr *( "," non-branched-expr ) ) "]"
+    multi-select-list = "[" ( expression *( "," expression ) ) "]"
     multi-select-hash = "{" ( keyval-expr *( "," keyval-expr ) ) "}"
-    keyval-expr       = identifier ":" non-branched-expr
-    non-branched-expr = identifier /
-                        non-branched-expr "." identifier /
-                        non-branched-expr "[" number "]"
+    keyval-expr       = identifier ":" expression
     bracket-specifier = "[" (number / "*") "]" / "[]"
     number            = [-]1*digit
     digit             = "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9" / "0"

--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -31,12 +31,9 @@ The grammar is specified using ABNF, as described in `RFC4234`_
     sub-expression    = expression "." expression
     or-expression     = expression "||" expression
     index-expression  = expression bracket-specifier / bracket-specifier
-    multi-select-list = "[" ( non-branched-expr *( "," non-branched-expr ) ) "]"
+    multi-select-list = "[" ( expression *( "," expression ) ) "]"
     multi-select-hash = "{" ( keyval-expr *( "," keyval-expr ) ) "}"
-    keyval-expr       = identifier ":" non-branched-expr
-    non-branched-expr = identifier /
-                        non-branched-expr "." identifier /
-                        non-branched-expr "[" number "]"
+    keyval-expr       = identifier ":" expression
     bracket-specifier = "[" (number / "*") "]" / "[]"
     number            = [-]1*digit
     digit             = "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9" / "0"
@@ -51,7 +48,6 @@ The grammar is specified using ABNF, as described in `RFC4234`_
                         %x5F /    ; _
                         %x61-7A / ; a-z
                         %x7F-10FFFF
-
 
 
 Identifiers
@@ -235,22 +231,18 @@ MultiSelect List
 
 ::
 
-    multi-select-list = "[" ( non-branched-expr *( "," non-branched-expr ) "]"
-    non-branched-expr = identifier /
-                        non-branched-expr "." identifier /
-                        non-branched-expr "[" number "]"
+    multi-select-list = "[" ( expression *( "," expression ) "]"
 
 A multiselect expression is used to extract a subset of elements from a JSON
 hash.  There are two version of multiselect, one in which the multiselect
 expression is enclosed in ``{...}`` and one which is enclosed in ``[...]``.
-This section describes the ``[...]`` version.
-Within the start and closing characters is one or more non
-branched expressions separated by a comma.  Each non branched expression will
-be evaluated against the JSON document.  Each returned element will be the
-result of evaluating the non branched expression. A ``multi-select-list`` with
-``N`` non branched expressions will result in a list of length ``N``.  Given a
-multiselect expression ``[expr-1,expr-2,...,expr-n]``, the evaluated expression
-will return ``[evaluate(expr-1), evaluate(expr-2), ..., evaluate(expr-n)]``.
+This section describes the ``[...]`` version.  Within the start and closing
+characters is one or more non expressions separated by a comma.  Each
+expression will be evaluated against the JSON document.  Each returned element
+will be the result of evaluating the expression. A ``multi-select-list`` with
+``N`` expressions will result in a list of length ``N``.  Given a multiselect
+expression ``[expr-1,expr-2,...,expr-n]``, the evaluated expression will return
+``[evaluate(expr-1), evaluate(expr-2), ..., evaluate(expr-n)]``.
 
 Examples
 --------
@@ -269,20 +261,17 @@ MultiSelect Hash
 ::
 
     multi-select-hash = "{" ( keyval-expr *( "," keyval-expr ) "}"
-    keyval-expr       = identifier ":" non-branched-expr
-    non-branched-expr = identifier /
-                        non-branched-expr "." identifier /
-                        non-branched-expr "[" number "]"
+    keyval-expr       = identifier ":" expression
 
 A ``multi-select-hash`` expression is similar to a ``multi-select-list``
 expression, except that a hash is created instead of a list.  A
 ``multi-select-hash`` expression also requires key names to be provided, as
 specified in the ``keyval-expr`` rule.  Given the following rule::
 
-    keyval-expr       = identifier ":" non-branched-expr
+    keyval-expr       = identifier ":" expression
 
 The ``identifier`` is used as the key name and the result of evaluating the
-``non-branched-expr`` is the value associated with the ``identifier`` key.
+``expression`` is the value associated with the ``identifier`` key.
 
 Each ``keyval-expr`` within the ``multi-select-hash`` will correspond to a
 single key value pair in the created hash.

--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -96,7 +96,7 @@ class Grammar(object):
         p[0] = ast.MultiFieldDict(p[2])
 
     def p_jmespath_multiselect_list(self, p):
-        """expression : LBRACKET nonbranched-exprs RBRACKET
+        """expression : LBRACKET expressions RBRACKET
         """
         p[0] = ast.MultiFieldList(p[2])
 
@@ -111,33 +111,19 @@ class Grammar(object):
             p[0] = p[1]
 
     def p_jmespath_keyval_expr(self, p):
-        """keyval-expr : IDENTIFIER COLON nonbranched-expr
+        """keyval-expr : IDENTIFIER COLON expression
         """
         p[0] = ast.KeyValPair(p[1], p[3])
 
-    def p_jmespath_multiselect_nonbranched_expressions(self, p):
-        """nonbranched-exprs : nonbranched-exprs COMMA nonbranched-expr
-                             | nonbranched-expr
+    def p_jmespath_multiple_expressions(self, p):
+        """expressions : expressions COMMA expression
+                       | expression
         """
         if len(p) == 2:
             p[0] = [p[1]]
         elif len(p) == 4:
             p[1].append(p[3])
             p[0] = p[1]
-
-    def p_jmespath_nonbranched_expression(self, p):
-        """nonbranched-expr : IDENTIFIER
-                            | nonbranched-expr DOT IDENTIFIER
-                            | nonbranched-expr LBRACKET NUMBER RBRACKET
-        """
-        if len(p) == 2:
-            p[0] = ast.Field(str(p[1]))
-        elif len(p) == 4:
-            # foo . bar
-            p[0] = ast.SubExpression(p[1], ast.Field(str(p[3])))
-        elif len(p) == 5:
-            # <scalaridentifier>[0]
-            p[0] = ast.SubExpression(p[1], ast.Index(p[3]))
 
     def p_jmespath_or_expression(self, p):
         """expression : expression OR expression"""

--- a/tests/compliance/multiselect.json
+++ b/tests/compliance/multiselect.json
@@ -173,7 +173,8 @@
 }, {
     "given": {
       "foo": {
-          "bar": {"baz": [{"one": 1}, {"two": 2}]},
+          "bar": {"baz": [{"common": "first", "one": 1},
+                          {"common": "second", "two": 2}]},
           "ignoreme": 1,
           "includeme": true
       }
@@ -181,11 +182,23 @@
     "cases": [
          {
             "expression": "foo.{bar: bar.baz[1],includeme: includeme}",
-            "result": {"bar": {"two": 2}, "includeme": true}
+            "result": {"bar": {"common": "second", "two": 2}, "includeme": true}
          },
          {
             "expression": "foo.{\"bar.baz.two\": bar.baz[1].two, includeme: includeme}",
             "result": {"bar.baz.two": 2, "includeme": true}
+         },
+         {
+            "expression": "foo.[includeme, bar.baz[*].common]",
+            "result": [true, ["first", "second"]]
+         },
+         {
+            "expression": "foo.[includeme, bar.baz[*].none]",
+            "result": [true, []]
+         },
+         {
+            "expression": "foo.[includeme, bar.baz[].common]",
+            "result": [true, ["first", "second"]]
          }
     ]
 }, {
@@ -286,6 +299,74 @@
         {
            "expression": "foo[].bar[].[baz, qux][]",
            "result": [1, 2, 3, 4, 5, 6, 7, 8]
+        }
+    ]
+},
+{
+    "given": {
+        "foo": {
+            "baz": [
+                {
+                    "bar": "abc"
+                }, {
+                    "bar": "def"
+                }
+            ],
+            "qux": ["zero"]
+        }
+    },
+    "cases": [
+        {
+           "expression": "foo.[baz[*].bar, qux[0]]",
+           "result": [["abc", "def"], "zero"]
+        }
+    ]
+},
+{
+    "given": {
+        "foo": {
+            "baz": [
+                {
+                    "bar": "a",
+                    "bam": "b",
+                    "boo": "c"
+                }, {
+                    "bar": "d",
+                    "bam": "e",
+                    "boo": "f"
+                }
+            ],
+            "qux": ["zero"]
+        }
+    },
+    "cases": [
+        {
+           "expression": "foo.[baz[*].[bar, boo], qux[0]]",
+           "result": [[["a", "c" ], ["d", "f" ]], "zero"]
+        }
+    ]
+},
+{
+    "given": {
+        "foo": {
+            "baz": [
+                {
+                    "bar": "a",
+                    "bam": "b",
+                    "boo": "c"
+                }, {
+                    "bar": "d",
+                    "bam": "e",
+                    "boo": "f"
+                }
+            ],
+            "qux": ["zero"]
+        }
+    },
+    "cases": [
+        {
+           "expression": "foo.[baz[*].not_there || baz[*].bar, qux[0]]",
+           "result": [[], "zero"]
         }
     ]
 }


### PR DESCRIPTION
This required updating the grammar, but no code changes were needed.
I've updated the compliance tests with the examples from the JEP.

Note that there was one example that was changed from the original
spec.  The OR expression example was changed because a wildcard
on a list type will never evaluate to `null`, and therefore will
always be selected if it's the first expression in an OR expression.

cc @mtdowling
