### PR TITLE
Don't project non list elements in flattening operator

### DIFF
--- a/jmespath/ast.py
+++ b/jmespath/ast.py
@@ -189,7 +189,7 @@ class ListElements(AST):
                     merged_list.append(element)
             return _Projection(merged_list)
         else:
-            return _Projection(value)
+            return None
 
     def pretty_print(self, indent=''):
         return "%sListElements()" % indent

--- a/tests/compliance/indices.json
+++ b/tests/compliance/indices.json
@@ -296,5 +296,51 @@
            "result": [1, 3, 5, 7]
         }
     ]
+},
+{
+    "given": {
+        "string": "string",
+        "hash": {"foo": "bar", "bar": "baz"},
+        "number": 23,
+        "nullvalue": null
+     },
+     "cases": [
+         {
+            "expression": "string[]",
+            "result": null
+         },
+         {
+            "expression": "hash[]",
+            "result": null
+         },
+         {
+            "expression": "number[]",
+            "result": null
+         },
+         {
+            "expression": "nullvalue[]",
+            "result": null
+         },
+         {
+            "expression": "string[].foo",
+            "result": null
+         },
+         {
+            "expression": "hash[].foo",
+            "result": null
+         },
+         {
+            "expression": "number[].foo",
+            "result": null
+         },
+         {
+            "expression": "nullvalue[].foo",
+            "result": null
+         },
+         {
+            "expression": "nullvalue[].foo[].bar",
+            "result": null
+         }
+     ]
 }
 ]


### PR DESCRIPTION
There was a similar fix for wildcards.  The flattening operator
needs this behavior as well.
