### PR TITLE
Return a ParsedResult class instead of raw AST node

### DIFF
--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -6,6 +6,7 @@ import ply.lex
 from jmespath import ast
 from jmespath import lexer
 from jmespath.compat import with_str_method
+from jmespath.compat import with_repr_method
 
 
 @with_str_method
@@ -220,10 +221,11 @@ class Parser(object):
                                write_tables=False)
         parsed = self._parse_expression(parser=parser, expression=expression,
                                         lexer_obj=lexer)
-        self._cache[expression] = parsed
+        parsed_result = ParsedResult(expression, parsed)
+        self._cache[expression] = parsed_result
         if len(self._cache) > self._max_size:
             self._free_cache_entries()
-        return parsed
+        return parsed_result
 
     def _parse_expression(self, parser, expression, lexer_obj):
         try:
@@ -249,3 +251,27 @@ class Parser(object):
     def purge(cls):
         """Clear the expression compilation cache."""
         cls._cache.clear()
+
+
+@with_repr_method
+class ParsedResult(object):
+    def __init__(self, expression, parsed):
+        self.expression = expression
+        self.parsed = parsed
+
+    def search(self, value):
+        return self.parsed.search(value)
+
+    def pretty_print(self, indent=''):
+        return self.parsed.pretty_print(indent=indent)
+
+    def __repr__(self):
+        return repr(self.parsed)
+
+    def __eq__(self, other):
+        return (isinstance(other, self.__class__)
+                and self.__dict__ == other.__dict__)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -33,9 +33,9 @@ class TestParser(unittest.TestCase):
 
     def test_quoted_subexpression(self):
         parsed = self.parser.parse('"foo"."bar"')
-        self.assertIsInstance(parsed, ast.SubExpression)
-        self.assertEqual(parsed.parent.name, 'foo')
-        self.assertEqual(parsed.child.name, 'bar')
+        self.assertIsInstance(parsed.parsed, ast.SubExpression)
+        self.assertEqual(parsed.parsed.parent.name, 'foo')
+        self.assertEqual(parsed.parsed.child.name, 'bar')
 
     def test_wildcard(self):
         parsed = self.parser.parse('foo[*]')
@@ -292,7 +292,15 @@ class TestParserCaching(unittest.TestCase):
         # cache but they should still be equal to compiled.
         for i in range(parser.Parser._max_size + 1):
             compiled2.append(p.parse('foo%s' % i))
+        self.assertEqual(len(compiled), len(compiled2))
         self.assertEqual(compiled, compiled2)
+
+
+class TestParserAddsExpressionAttribute(unittest.TestCase):
+    def test_expression_available_from_parser(self):
+        p = parser.Parser()
+        parsed = p.parse('foo.bar')
+        self.assertEqual(parsed.expression, 'foo.bar')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This allows us to set additional properties on the result
object without adding per-AST node specific attributes that would
only exist on the root node.  The only one I've added for now
is "expression", which lets a user get the original expression
associated with the parsed value.

cc @toastdriven
