### PR TITLE
Corrected example for negative indexing in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ syntax::
 The expression: ``foo.bar[*].name`` will return ["one", "two"].
 Negative indexing is also supported (-1 refers to the last element
 in the list).  Given the data above, the expression
-``foo.bar[-1].name`` will return ["two"].
+``foo.bar[-1].name`` will return "two".
 
 The ``*`` can also be used for hash types::
 


### PR DESCRIPTION
An earlier example indicates that `foo.bar[0]` returns "one".  Logic follows that `foo.bar[-1]` should also return a scalar value and not an array of values.
