### PR TITLE
Add a compliance test runner

### DIFF
--- a/bin/jp
+++ b/bin/jp
@@ -1,17 +1,57 @@
 #!/usr/bin/env python
 
-import jmespath
 import sys
 import json
+import argparse
 
-if not len(sys.argv) >= 2:
-    sys.stderr.write('usage: jp <expression> <filepath>\n\n')
-    sys.exit(1)
-expression = sys.argv[1]
-if len(sys.argv) == 3:
-    with open(sys.argv[2], 'r') as f:
-        data = json.load(f)
-else:
-    data = json.load(sys.stdin)
-sys.stdout.write(json.dumps(jmespath.search(expression, data), indent=4))
-sys.stdout.write('\n')
+import jmespath
+from jmespath.parser import ParseError, ArityError
+from jmespath.lexer import LexerError
+from jmespath.ast import JMESPathTypeError, UnknownFunctionError
+from jmespath.compat import OrderedDict
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('expression')
+    parser.add_argument('-o', '--ordered', action='store_true',
+                        help='Preserve the order of hash keys, which '
+                             'are normally unordered.')
+    parser.add_argument('-f', '--filename',
+                        help=('The filename containing the input data.  '
+                              'If a filename is not given then data is '
+                              'read from stdin.'))
+    args = parser.parse_args()
+    expression = args.expression
+    if args.filename:
+        with open(args.filename, 'r') as f:
+            data = json.load(f)
+    else:
+        data = sys.stdin.read()
+        if args.ordered:
+            data = json.loads(data, object_pairs_hook=OrderedDict)
+        else:
+            data = json.loads(data)
+    try:
+        sys.stdout.write(json.dumps(
+            jmespath.search(expression, data), indent=4))
+        sys.stdout.write('\n')
+    except ArityError as e:
+        sys.stderr.write("invalid-arity: %s\n" % e)
+        return 1
+    except JMESPathTypeError as e:
+        sys.stderr.write("invalid-type: %s\n" % e)
+        return 1
+    except UnknownFunctionError as e:
+        sys.stderr.write("unknown-function: %s\n" % e)
+        return 1
+    except ParseError as e:
+        sys.stderr.write("syntax-error: %s\n" % e)
+        return 1
+    except LexerError as e:
+        sys.stderr.write("syntax-error: %s\n" % e)
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/bin/jp-compliance
+++ b/bin/jp-compliance
@@ -55,6 +55,14 @@ import json
 import shlex
 
 
+if sys.version_info[:2] == (2, 6):
+    import simplejson as json
+    from ordereddict import OrderedDict
+else:
+    import json
+    from collections import OrderedDict
+
+
 _abs = os.path.abspath
 _dname = os.path.dirname
 _pjoin = os.path.join
@@ -94,7 +102,7 @@ class ComplianceTestRunner(object):
 
     def _load_test_file(self, test_json_file):
         with open(test_json_file) as f:
-            loaded_test = json.loads(f.read())
+            loaded_test = json.loads(f.read(), object_pairs_hook=OrderedDict)
         return loaded_test
 
     def _load_test_cases(self, filename, group_number, test_group):
@@ -184,6 +192,7 @@ def test_spec(value):
     if len(parts) == 2:
         spec['group_number'] = int(parts[1])
     elif len(parts) == 3:
+        spec['group_number'] = int(parts[1])
         spec['test_number'] = int(parts[2])
     return spec
 

--- a/jmespath/ast.py
+++ b/jmespath/ast.py
@@ -54,6 +54,10 @@ class JMESPathTypeError(ValueError):
                     self.expected_types, jmespath_actual))
 
 
+class UnknownFunctionError(ValueError):
+    pass
+
+
 class _Arg(object):
     __slots__ = ('types',)
 
@@ -411,7 +415,7 @@ class FunctionExpression(AST):
         try:
             self.function = getattr(self, '_func_%s' % name)
         except AttributeError:
-            raise ValueError("Unknown function: %s" % self.name)
+            raise UnknownFunctionError("Unknown function: %s" % self.name)
         self.arity = self.function.arity
         self.variadic = self.function.variadic
         self.function = self._resolve_arguments_wrapper(self.function)

--- a/jmespath/compat.py
+++ b/jmespath/compat.py
@@ -38,3 +38,11 @@ else:
         return cls
     def with_repr_method(cls):
         return cls
+
+
+if sys.version_info[:2] == (2, 6):
+    from ordereddict import OrderedDict
+    import simplejson as json
+else:
+    from collections import OrderedDict
+    import json

--- a/jmespath/lexer.py
+++ b/jmespath/lexer.py
@@ -150,4 +150,6 @@ class LexerDefinition(object):
                 lexer_value=t.value,
                 message=("Bad token '%s': starting quote is missing "
                          "the ending quote" % t.value))
-        raise ValueError("Illegal token value '%s'" % t.value)
+        raise LexerError(lexer_position=t.lexpos,
+                         lexer_value=t.value,
+                         message=("Illegal token value '%s'" % t.value))

--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -226,8 +226,13 @@ class Grammar(object):
 
     def p_jmespath_function_expression(self, p):
         """function-expression : UNQUOTED_IDENTIFIER LPAREN function-args RPAREN
+                               | UNQUOTED_IDENTIFIER LPAREN RPAREN
         """
-        function_node = ast.FunctionExpression(p[1], p[3])
+        if len(p) == 5:
+            args = p[3]
+        else:
+            args = []
+        function_node = ast.FunctionExpression(p[1], args)
         if function_node.variadic:
             if len(function_node.args) < function_node.arity:
                 raise VariadictArityError(function_node)

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,22 @@ import sys
 from setuptools import setup, find_packages
 
 
+requires = ['ply==3.4']
+
+
+if sys.version_info[:2] == (2, 6):
+    # For python2.6 we have a few other dependencies.
+    # First we need an ordered dictionary so we use the
+    # 2.6 backport.
+    requires.append('ordereddict==1.1')
+    # Then we need simplejson.  This is because we need
+    # a json version that allows us to specify we want to
+    # use an ordereddict instead of a normal dict for the
+    # JSON objects.  The 2.7 json module has this.  For 2.6
+    # we need simplejson.
+    requires.append('simplejson==3.3.0')
+
+
 setup(
     name='jmespath',
     version='0.3.0',
@@ -16,9 +32,7 @@ setup(
     url='https://github.com/boto/jmespath',
     scripts=['bin/jp'],
     packages=find_packages(exclude=['tests']),
-    install_requires=[
-        'ply==3.4',
-    ],
+    install_requires=requires,
     classifiers=(
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This makes it possible for other implementations to run tests
against the compliance tests in this repo.  All you need is
an executable that takes the expression as a command line argument
and the data on stdin.

Validated that all compliance tests pass with:

```
bin/jp-compliance --exe "jp -o"
```
