### PR TITLE
Add starts_with, ends_with, reverse functions

### DIFF
--- a/docs/specification.rst
+++ b/docs/specification.rst
@@ -894,6 +894,34 @@ Returns the next highest integer value by rounding up if necessary.
   * - ``ceil(`abc`)``
     - ``null``
 
+ends_with
+---------
+
+::
+
+    boolean floor(string $value)
+
+Returns ``true`` if the ``$subject`` ends with the ``$prefix``, otherwise this
+function returns ``false``.
+
+
+.. list-table:: Examples
+  :header-rows: 1
+
+  * - Given
+    - Expression
+    - Result
+  * - ``foobarbaz``
+    - ``ends_with(@, ``baz``)``
+    - ``true``
+  * - ``foobarbaz``
+    - ``ends_with(@, ``foo``)``
+    - ``false``
+  * - ``foobarbaz``
+    - ``ends_with(@, ``z``)``
+    - ``true``
+
+
 floor
 -----
 
@@ -1158,6 +1186,33 @@ then a value of ``null`` is returned.
     - ``null``
 
 
+reverse
+-------
+
+::
+
+    array reverse(array $argument)
+
+Reverses the order of the ``$argument``.
+
+
+.. list-table:: Examples
+  :header-rows: 1
+
+  * - Given
+    - Expression
+    - Result
+  * - ``[0, 1, 2, 3, 4]``
+    - ``reverse(@)``
+    - ``[4, 3, 2, 1, 0]``
+  * - ``[]
+    - ``reverse(@)``
+    - ``[]``
+  * - ``["a", "b", "c", 1, 2, 3]``
+    - ``reverse(@)``
+    - ``[3, 2, 1, "c", "b", "a"]``
+
+
 sort
 ----
 
@@ -1223,6 +1278,33 @@ function.
     - ``{"age": 10, "age_str": "10", "bool": true, "name": 3}``
   * - ``sort_by(people, &to_number(age_str))[0]``
     - ``{"age": 10, "age_str": "10", "bool": true, "name": 3}``
+
+
+starts_with
+-----------
+
+::
+
+    boolean starts_with(string $subject, string $prefix)
+
+Returns ``true`` if the ``$subject`` starts with the ``$prefix``, otherwise
+this function returns ``false``.
+
+.. list-table:: Examples
+  :header-rows: 1
+
+  * - Given
+    - Expression
+    - Result
+  * - ``foobarbaz``
+    - ``starts_with(@, ``foo``)``
+    - ``true``
+  * - ``foobarbaz``
+    - ``starts_with(@, ``baz``)``
+    - ``false``
+  * - ``foobarbaz``
+    - ``starts_with(@, ``f``)``
+    - ``true``
 
 
 to_string

--- a/jmespath/ast.py
+++ b/jmespath/ast.py
@@ -576,6 +576,10 @@ class FunctionExpression(AST):
     def _func_ceil(self, arg):
         return math.ceil(arg)
 
+    @signature(_Arg(types=['string']), _Arg(types=['string']))
+    def _func_ends_with(self, search, suffix):
+        return search.endswith(suffix)
+
     @signature(_Arg(types=['number']))
     def _func_floor(self, arg):
         return math.floor(arg)
@@ -601,6 +605,14 @@ class FunctionExpression(AST):
     @signature(_Arg(types=['array-string', 'array-number']))
     def _func_sort(self, arg):
         return list(sorted(arg))
+
+    @signature(_Arg(types=['string']), _Arg(types=['string']))
+    def _func_starts_with(self, search, prefix):
+        return search.startswith(prefix)
+
+    @signature(_Arg(types=['array']))
+    def _func_reverse(self, arg):
+        return list(reversed(arg))
 
     @signature(_Arg(types=['object']))
     def _func_keys(self, arg):

--- a/tests/compliance/functions.json
+++ b/tests/compliance/functions.json
@@ -128,6 +128,30 @@
       "result": false
     },
     {
+      "expression": "ends_with(str, `r`)",
+      "result": true
+    },
+    {
+      "expression": "ends_with(str, `tr`)",
+      "result": true
+    },
+    {
+      "expression": "ends_with(str, `Str`)",
+      "result": true
+    },
+    {
+      "expression": "ends_with(str, `SStr`)",
+      "result": false
+    },
+    {
+      "expression": "ends_with(str, `foo`)",
+      "result": false
+    },
+    {
+      "expression": "ends_with(str, `0`)",
+      "error": "invalid-type"
+    },
+    {
       "expression": "floor(`1.2`)",
       "result": 1
     },
@@ -338,6 +362,38 @@
     {
       "expression": "join(`|`, empty_list)",
       "result": ""
+    },
+    {
+      "expression": "reverse(numbers)",
+      "result": [5, 4, 3, -1]
+    },
+    {
+      "expression": "reverse(array)",
+      "result": ["100", "a", 5, 4, 3, -1]
+    },
+    {
+      "expression": "reverse(`[]`)",
+      "result": []
+    },
+    {
+      "expression": "starts_with(str, `S`)",
+      "result": true
+    },
+    {
+      "expression": "starts_with(str, `St`)",
+      "result": true
+    },
+    {
+      "expression": "starts_with(str, `Str`)",
+      "result": true
+    },
+    {
+      "expression": "starts_with(str, `String`)",
+      "result": false
+    },
+    {
+      "expression": "starts_with(str, `0`)",
+      "error": "invalid-type"
     },
     {
       "expression": "to_string(`foo`)",


### PR DESCRIPTION
I think these functions would be useful, but am open to hearing suggestions.  I know that some of these can be accomplished with the array slicing JEP, but these arguably provide a more convenient way to do this (`foo[::-1]` vs. reverse(foo)).
