### PR TITLE
Raise proper exception when parsing an empty string

### DIFF
--- a/jmespath/exceptions.py
+++ b/jmespath/exceptions.py
@@ -102,5 +102,11 @@ class JMESPathTypeError(JMESPathError):
                     self.expected_types, self.actual_type))
 
 
+class EmptyExpressionError(JMESPathError):
+    def __init__(self):
+        super(EmptyExpressionError, self).__init__(
+            "Invalid JMESPath expression: cannot be empty.")
+
+
 class UnknownFunctionError(JMESPathError):
     pass

--- a/jmespath/lexer.py
+++ b/jmespath/lexer.py
@@ -1,7 +1,7 @@
 import re
 from json import loads
 
-from jmespath.exceptions import LexerError
+from jmespath.exceptions import LexerError, EmptyExpressionError
 
 
 class Lexer(object):
@@ -39,6 +39,8 @@ class Lexer(object):
         self.master_regex = re.compile(self.TOKENS)
 
     def tokenize(self, expression):
+        if not expression:
+            raise EmptyExpressionError()
         previous_column = 0
         for match in self.master_regex.finditer(expression):
             value = match.group()

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,7 +1,7 @@
 from tests import unittest
 
 from jmespath import lexer
-from jmespath.exceptions import LexerError
+from jmespath.exceptions import LexerError, EmptyExpressionError
 
 
 class TestRegexLexer(unittest.TestCase):
@@ -25,6 +25,10 @@ class TestRegexLexer(unittest.TestCase):
         self.assertEqual(stripped[-1]['type'], 'eof')
         stripped.pop()
         self.assertEqual(stripped, expected)
+
+    def test_empty_string(self):
+        with self.assertRaises(EmptyExpressionError):
+            list(self.lexer.tokenize(''))
 
     def test_field(self):
         tokens = list(self.lexer.tokenize('foo'))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -17,6 +17,10 @@ class TestParser(unittest.TestCase):
         parsed = self.parser.parse(expression)
         self.assertEqual(parsed.parsed, expected_ast)
 
+    def test_parse_empty_string_raises_exception(self):
+        with self.assertRaises(exceptions.EmptyExpressionError):
+            self.parser.parse('')
+
     def test_field(self):
         self.assert_parsed_ast('foo', ast.field('foo'))
 


### PR DESCRIPTION
You'd previously get an `UnboundLocalError`.  You now get an `EmptyExpressionError`.
