### PR TITLE
Allow to_string to work with python types

### DIFF
--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -190,7 +190,8 @@ class RuntimeFunctions(object):
         if isinstance(arg, STRING_TYPE):
             return arg
         else:
-            return json.dumps(arg, separators=(',', ':'))
+            return json.dumps(arg, separators=(',', ':'),
+                              default=str)
 
     @builtin_function({'types': []})
     def _func_to_number(self, arg):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+from tests import unittest
+from datetime import datetime, timedelta
+import json
+
+import jmespath
+
+
+class TestFunctions(unittest.TestCase):
+
+    def test_can_max_datetimes(self):
+        # This is python specific behavior, but JMESPath does not specify what
+        # you should do with language specific types.  We're going to add the
+        # ability that ``to_string`` will always default to str()'ing values it
+        # doesn't understand.
+        data = [datetime.now(), datetime.now() + timedelta(seconds=1)]
+        result = jmespath.search('max([*].to_string(@))', data)
+        self.assertEqual(json.loads(result), str(data[-1]))


### PR DESCRIPTION
The default behavior is to just str() them, which
is better behavior than to do nothing.

The spec does not specify what should happen with
language specific types (it only assumes JSON types),
so we're not violating the spec.  It accomodates the
use case where you want to be able to work with a python
type as an expref, for example::

```
  >>> import jmespath
  >>> from datetime import datetime, timedelta
  >>> data = [
      {"time": datetime.now(), "other": "foo"},
      {"time": datetime.now() + timedelta(seconds=1), "other": "bar"}]
  >>> jmespath.search('max_by(@, &to_string(time)).other', data)
  'bar'
```

cc @danielgtaylor @kyleknap 
