### PR TITLE
Add to_array and merge functions

### DIFF
--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -186,6 +186,13 @@ class RuntimeFunctions(object):
                 return argument
 
     @builtin_function({'types': []})
+    def _func_to_array(self, arg):
+        if isinstance(arg, list):
+            return arg
+        else:
+            return [arg]
+
+    @builtin_function({'types': []})
     def _func_to_string(self, arg):
         if isinstance(arg, STRING_TYPE):
             return arg

--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -259,6 +259,13 @@ class RuntimeFunctions(object):
         else:
             return None
 
+    @builtin_function({"types": ["object"], "variadic": True})
+    def _func_merge(self, *arguments):
+        merged = {}
+        for arg in arguments:
+            merged.update(arg)
+        return merged
+
     @builtin_function({"types": ['array-number', 'array-string']})
     def _func_min(self, arg):
         if arg:

--- a/tests/compliance/functions.json
+++ b/tests/compliance/functions.json
@@ -432,6 +432,26 @@
       "result": 0
     },
     {
+      "expression": "to_array(`foo`)",
+      "result": ["foo"]
+    },
+    {
+      "expression": "to_array(`0`)",
+      "result": [0]
+    },
+    {
+      "expression": "to_array(objects)",
+      "result": [{"foo": "bar", "bar": "baz"}]
+    },
+    {
+      "expression": "to_array(`[1, 2, 3]`)",
+      "result": [1, 2, 3]
+    },
+    {
+      "expression": "to_array(false)",
+      "result": [false]
+    },
+    {
       "expression": "to_string(`foo`)",
       "result": "foo"
     },

--- a/tests/compliance/functions.json
+++ b/tests/compliance/functions.json
@@ -240,6 +240,26 @@
       "result": null
     },
     {
+      "expression": "merge(`{}`)",
+      "result": {}
+    },
+    {
+      "expression": "merge(`{}`, `{}`)",
+      "result": {}
+    },
+    {
+      "expression": "merge(`{\"a\": 1}`, `{\"b\": 2}`)",
+      "result": {"a": 1, "b": 2}
+    },
+    {
+      "expression": "merge(`{\"a\": 1}`, `{\"a\": 2}`)",
+      "result": {"a": 2}
+    },
+    {
+      "expression": "merge(`{\"a\": 1, \"b\": 2}`, `{\"a\": 2, \"c\": 3}`, `{\"d\": 4}`)",
+      "result": {"a": 2, "b": 2, "c": 3, "d": 4}
+    },
+    {
       "expression": "min(numbers)",
       "result": -1
     },


### PR DESCRIPTION
Closes #52

`array to_array(any $argument)` - If `$argument` is an array, then `$argument` is returned.  Otherwise, a one item list containing `$argument` is returned.  Motivating example:

```
{
  "foo": [
    {
      "instances": [
        {
          "name": "foo"
        },
        {
          "name": "bar"
        }
      ]
    },
    {
      "instances": [
        {
          "name": "baz"
        }
      ]
    },
    {
      "instances": {
        "name": "other"
      }
    }
  ]
}
```

Here we want to have a list of sublists that contain instance names.  However, we also want to normalize the last instance key, which is a hash instead of a list.  Using `to_array` you can use:

```
$ jp -f /tmp/input 'foo[*].to_array(instances)[*].name'
[
    [
        "foo",
        "bar"
    ],
    [
        "baz"
    ],
    [
        "other"
    ]
]
```

`object merge(object $argument [, object $...])` - Each hash in the argument list is merged into the previous hash.  The motivation for this is described in #52.