### PR TITLE
Clean up error messages

### DIFF
--- a/bin/jp
+++ b/bin/jp
@@ -51,9 +51,6 @@ def main():
     except exceptions.UnknownFunctionError as e:
         sys.stderr.write("unknown-function: %s\n" % e)
         return 1
-    except exceptions.LexerError as e:
-        sys.stderr.write("syntax-error: %s\n" % e)
-        return 1
     except exceptions.ParseError as e:
         sys.stderr.write("syntax-error: %s\n" % e)
         return 1

--- a/jmespath/exceptions.py
+++ b/jmespath/exceptions.py
@@ -71,19 +71,29 @@ class ArityError(ParseError):
         self.expression = None
 
     def __str__(self):
-        return ("Expected %s arguments for function %s(), "
-                "received %s" % (self.expected_arity,
-                                 self.function_name,
-                                 self.actual_arity))
+        return ("Expected %s %s for function %s(), "
+                "received %s" % (
+                    self.expected_arity,
+                    self._pluralize('argument', self.expected_arity),
+                    self.function_name,
+                    self.actual_arity))
+
+    def _pluralize(self, word, count):
+        if count == 1:
+            return word
+        else:
+            return word + 's'
 
 
 @with_str_method
 class VariadictArityError(ArityError):
     def __str__(self):
-        return ("Expected at least %s arguments for function %s, "
-                "received %s" % (self.expected_arity,
-                                 self.function_name,
-                                 self.actual_arity))
+        return ("Expected at least %s %s for function %s(), "
+                "received %s" % (
+                    self.expected_arity,
+                    self._pluralize('argument', self.expected_arity),
+                    self.function_name,
+                    self.actual_arity))
 
 
 @with_str_method

--- a/jmespath/exceptions.py
+++ b/jmespath/exceptions.py
@@ -22,8 +22,8 @@ class ParseError(JMESPathError):
         # self.lex_position +1 to account for the starting double quote char.
         underline = ' ' * (self.lex_position + 1) + '^'
         return (
-            '%s: Parse error at column %s near '
-            'token "%s" (%s) for expression:\n"%s"\n%s' % (
+            '%s: Parse error at column %s, '
+            'token "%s" (%s), for expression:\n"%s"\n%s' % (
                 self.msg, self.lex_position, self.token_value, self.token_type,
                 self.expression, underline))
 

--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -317,7 +317,7 @@ class RuntimeFunctions(object):
         # that validates that type, which requires that remaining array
         # elements resolve to the same type as the first element.
         required_type = self._convert_to_jmespath_type(
-            self.interpreter.visit(expref.expression, array[0]))
+            type(self.interpreter.visit(expref.expression, array[0])).__name__)
         if required_type not in ['number', 'string']:
             raise exceptions.JMESPathTypeError(
                 'sort_by', array[0], required_type, ['string', 'number'])
@@ -345,7 +345,9 @@ class RuntimeFunctions(object):
 
         def keyfunc(x):
             result = interpreter.visit(expr_node, x)
-            jmespath_type = self._convert_to_jmespath_type(result)
+            actual_typename = type(result).__name__
+            jmespath_type = self._convert_to_jmespath_type(actual_typename)
+            # allowed_types is in term of jmespath types, not python types.
             if jmespath_type not in allowed_types:
                 raise exceptions.JMESPathTypeError(
                     function_name, result, jmespath_type, allowed_types)
@@ -353,4 +355,4 @@ class RuntimeFunctions(object):
         return keyfunc
 
     def _convert_to_jmespath_type(self, pyobject):
-        return TYPES_MAP.get(type(pyobject).__name__, 'unknown')
+        return TYPES_MAP.get(pyobject, 'unknown')

--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -427,6 +427,9 @@ class Parser(object):
                 "Token %s not allowed to be: %s" % (actual_type, token_types))
 
     def _error_nud_token(self, token):
+        if token['type'] == 'eof':
+            raise exceptions.IncompleteExpressionError(
+                token['start'], token['value'], token['type'])
         raise exceptions.ParseError(token['start'], token['value'],
                                     token['type'], 'Invalid token.')
 

--- a/tests/compliance/functions.json
+++ b/tests/compliance/functions.json
@@ -609,7 +609,7 @@
   },
   "cases": [
     {
-      "description": "function projection on variadic function",
+      "description": "sort by field expression",
       "expression": "sort_by(people, &age)",
       "result": [
          {"age": 10, "age_str": "10", "bool": true, "name": 3},
@@ -620,7 +620,7 @@
       ]
     },
     {
-      "description": "function projection on variadic function",
+      "description": "sort by function expression",
       "expression": "sort_by(people, &to_number(age_str))",
       "result": [
          {"age": 10, "age_str": "10", "bool": true, "name": 3},
@@ -631,7 +631,7 @@
       ]
     },
     {
-      "description": "function projection on variadic function",
+      "description": "function projection on sort_by function",
       "expression": "sort_by(people, &age)[].name",
       "result": [3, "a", "c", "b", "d"]
     },
@@ -654,6 +654,10 @@
     {
       "expression": "sort_by(people, &age)[].extra",
       "result": ["foo", "bar"]
+    },
+    {
+      "expression": "sort_by(`[]`, &age)",
+      "result": []
     },
     {
       "expression": "max_by(people, &age)",

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 import json
 
 import jmespath
+from jmespath.exceptions import JMESPathTypeError
 
 
 class TestFunctions(unittest.TestCase):
@@ -16,3 +17,17 @@ class TestFunctions(unittest.TestCase):
         data = [datetime.now(), datetime.now() + timedelta(seconds=1)]
         result = jmespath.search('max([*].to_string(@))', data)
         self.assertEqual(json.loads(result), str(data[-1]))
+
+    def test_type_error_messages(self):
+        with self.assertRaises(JMESPathTypeError) as e:
+            jmespath.search('length(@)', 2)
+        exception = e.exception
+        # 1. Function name should be in error message
+        self.assertIn('length()', str(exception))
+        # 2. Mention it's an invalid type
+        self.assertIn('invalid type for value: 2', str(exception))
+        # 3. Mention the valid types:
+        self.assertIn("expected one of: ['string', 'array', 'object']",
+                      str(exception))
+        # 4. Mention the actual type.
+        self.assertIn('received: "number"', str(exception))

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 import json
 
 import jmespath
-from jmespath.exceptions import JMESPathTypeError
+from jmespath import exceptions
 
 
 class TestFunctions(unittest.TestCase):
@@ -19,7 +19,7 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(json.loads(result), str(data[-1]))
 
     def test_type_error_messages(self):
-        with self.assertRaises(JMESPathTypeError) as e:
+        with self.assertRaises(exceptions.JMESPathTypeError) as e:
             jmespath.search('length(@)', 2)
         exception = e.exception
         # 1. Function name should be in error message
@@ -31,3 +31,27 @@ class TestFunctions(unittest.TestCase):
                       str(exception))
         # 4. Mention the actual type.
         self.assertIn('received: "number"', str(exception))
+
+    def test_singular_in_error_message(self):
+        with self.assertRaises(exceptions.ArityError) as e:
+            jmespath.search('length(@, @)', [0, 1])
+        exception = e.exception
+        self.assertEqual(
+            str(exception),
+            'Expected 1 argument for function length(), received 2')
+
+    def test_error_message_is_pluralized(self):
+        with self.assertRaises(exceptions.ArityError) as e:
+            jmespath.search('sort_by(@)', [0, 1])
+        exception = e.exception
+        self.assertEqual(
+            str(exception),
+            'Expected 2 arguments for function sort_by(), received 1')
+
+    def test_variadic_is_pluralized(self):
+        with self.assertRaises(exceptions.VariadictArityError) as e:
+            jmespath.search('not_null()', 'foo')
+        exception = e.exception
+        self.assertEqual(
+            str(exception),
+            'Expected at least 1 argument for function not_null(), received 0')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -121,8 +121,8 @@ class TestErrorMessages(unittest.TestCase):
 
     def test_bad_parse_error_message(self):
         error_message = (
-            'Unexpected token: ]: Parse error at column 3 '
-            'near token "]" (RBRACKET) for expression:\n'
+            'Unexpected token: ]: Parse error at column 3, '
+            'token "]" (RBRACKET), for expression:\n'
             '"foo]baz"\n'
             '    ^')
         self.assert_error_message('foo]baz', error_message)
@@ -133,6 +133,13 @@ class TestErrorMessages(unittest.TestCase):
             '"foo.{bar: baz,bar: bar"\n'
             '                       ^')
         self.assert_error_message('foo.{bar: baz,bar: bar', error_message)
+
+    def test_incomplete_expression_with_missing_paren(self):
+        error_message = (
+            'Invalid jmespath expression: Incomplete expression:\n'
+            '"length(@,"\n'
+            '          ^')
+        self.assert_error_message('length(@,', error_message)
 
     def test_bad_lexer_values(self):
         error_message = (


### PR DESCRIPTION
1. Fix type error messages, the actual type was always being displayed as a string
2. Only pluralize "arguments" if the expected number of arguments is > 1.
3. Handle a few cases where the more specific `IncompleteExpressionError` could be raised instead of the more generic `ParseError`, notably missing closing parens and lbrackets.