### PR TITLE
Implement Jep 12 - Raw String Literals

### DIFF
--- a/jmespath/lexer.py
+++ b/jmespath/lexer.py
@@ -9,6 +9,7 @@ class Lexer(object):
         r'(?P<number>-?\d+)|'
         r'(?P<unquoted_identifier>([a-zA-Z_][a-zA-Z_0-9]*))|'
         r'(?P<quoted_identifier>("(?:\\\\|\\"|[^"])*"))|'
+        r'(?P<string_literal>(\'(?:\\\\|\\\'|[^\'])*\'))|'
         r'(?P<literal>(`(?:\\\\|\\`|[^`])*`))|'
         r'(?P<filter>\[\?)|'
         r'(?P<or>\|\|)|'
@@ -92,6 +93,9 @@ class Lexer(object):
             raise LexerError(lexer_position=start,
                              lexer_value=value,
                              message=error_message)
+
+    def _token_string_literal(self, value, start, end):
+        return value[1:-1]
 
     def _token_literal(self, value, start, end):
         actual_value = value[1:-1]

--- a/jmespath/lexer.py
+++ b/jmespath/lexer.py
@@ -113,7 +113,8 @@ class Lexer(object):
                 # don't have to be quoted.  This is only true if the
                 # string doesn't start with chars that could start a valid
                 # JSON value.
-                return loads(potential_value)
+                value = loads(potential_value)
+                return value
             except ValueError:
                 raise LexerError(lexer_position=start,
                                  lexer_value=value,

--- a/jmespath/lexer.py
+++ b/jmespath/lexer.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from json import loads
 
 from jmespath.exceptions import LexerError, EmptyExpressionError
@@ -118,6 +119,8 @@ class Lexer(object):
                 # string doesn't start with chars that could start a valid
                 # JSON value.
                 value = loads(potential_value)
+                warnings.warn("deprecated string literal syntax",
+                              PendingDeprecationWarning)
                 return value
             except ValueError:
                 raise LexerError(lexer_position=start,

--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -127,6 +127,9 @@ class Parser(object):
                 current_token = self._current_token()
         return left
 
+    def _token_nud_string_literal(self, token):
+        return ast.literal(token['value'])
+
     def _token_nud_literal(self, token):
         return ast.literal(token['value'])
 

--- a/tests/compliance/filters.json
+++ b/tests/compliance/filters.json
@@ -4,7 +4,7 @@
     "cases": [
       {
         "comment": "Matching a literal",
-        "expression": "foo[?name == `a`]",
+        "expression": "foo[?name == `\"a\"`]",
         "result": [{"name": "a"}]
       }
     ]
@@ -86,7 +86,7 @@
     "cases": [
       {
         "comment": "Filter with subexpression",
-        "expression": "foo[?top.name == `a`]",
+        "expression": "foo[?top.name == `\"a\"`]",
         "result": [{"top": {"name": "a"}}]
       }
     ]

--- a/tests/compliance/filters.json
+++ b/tests/compliance/filters.json
@@ -4,7 +4,7 @@
     "cases": [
       {
         "comment": "Matching a literal",
-        "expression": "foo[?name == `\"a\"`]",
+        "expression": "foo[?name == 'a']",
         "result": [{"name": "a"}]
       }
     ]
@@ -86,7 +86,7 @@
     "cases": [
       {
         "comment": "Filter with subexpression",
-        "expression": "foo[?top.name == `\"a\"`]",
+        "expression": "foo[?top.name == 'a']",
         "result": [{"top": {"name": "a"}}]
       }
     ]

--- a/tests/compliance/functions.json
+++ b/tests/compliance/functions.json
@@ -68,7 +68,7 @@
       "error": "invalid-type"
     },
     {
-      "expression": "avg(`abc`)",
+      "expression": "avg(`\"abc\"`)",
       "error": "invalid-type"
     },
     {
@@ -100,23 +100,23 @@
       "result": -1
     },
     {
-      "expression": "ceil(`string`)",
+      "expression": "ceil(`\"string\"`)",
       "error": "invalid-type"
     },
     {
-      "expression": "contains(`abc`, `a`)",
+      "expression": "contains(`\"abc\"`, `\"a\"`)",
       "result": true
     },
     {
-      "expression": "contains(`abc`, `d`)",
+      "expression": "contains(`\"abc\"`, `\"d\"`)",
       "result": false
     },
     {
-      "expression": "contains(`false`, `d`)",
+      "expression": "contains(`false`, `\"d\"`)",
       "error": "invalid-type"
     },
     {
-      "expression": "contains(strings, `a`)",
+      "expression": "contains(strings, `\"a\"`)",
       "result": true
     },
     {
@@ -128,23 +128,23 @@
       "result": false
     },
     {
-      "expression": "ends_with(str, `r`)",
+      "expression": "ends_with(str, `\"r\"`)",
       "result": true
     },
     {
-      "expression": "ends_with(str, `tr`)",
+      "expression": "ends_with(str, `\"tr\"`)",
       "result": true
     },
     {
-      "expression": "ends_with(str, `Str`)",
+      "expression": "ends_with(str, `\"Str\"`)",
       "result": true
     },
     {
-      "expression": "ends_with(str, `SStr`)",
+      "expression": "ends_with(str, `\"SStr\"`)",
       "result": false
     },
     {
-      "expression": "ends_with(str, `foo`)",
+      "expression": "ends_with(str, `\"foo\"`)",
       "result": false
     },
     {
@@ -156,7 +156,7 @@
       "result": 1
     },
     {
-      "expression": "floor(`string`)",
+      "expression": "floor(`\"string\"`)",
       "error": "invalid-type"
     },
     {
@@ -172,7 +172,7 @@
       "error": "invalid-type"
     },
     {
-      "expression": "length(`abc`)",
+      "expression": "length(`\"abc\"`)",
       "result": 3
     },
     {
@@ -288,7 +288,7 @@
       "result": "a"
     },
     {
-      "expression": "type(`abc`)",
+      "expression": "type(`\"abc\"`)",
       "result": "string"
     },
     {
@@ -356,23 +356,23 @@
       "result": "a, b, c"
     },
     {
-      "expression": "join(`, `, strings)",
+      "expression": "join(`\", \"`, strings)",
       "result": "a, b, c"
     },
     {
-      "expression": "join(`,`, `[\"a\", \"b\"]`)",
+      "expression": "join(`\",\"`, `[\"a\", \"b\"]`)",
       "result": "a,b"
     },
     {
-      "expression": "join(`,`, `[\"a\", 0]`)",
+      "expression": "join(`\",\"`, `[\"a\", 0]`)",
       "error": "invalid-type"
     },
     {
-      "expression": "join(`, `, str)",
+      "expression": "join(`\", \"`, str)",
       "error": "invalid-type"
     },
     {
-      "expression": "join(`|`, strings)",
+      "expression": "join(`\"|\"`, strings)",
       "result": "a|b|c"
     },
     {
@@ -380,15 +380,15 @@
       "error": "invalid-type"
     },
     {
-      "expression": "join(`|`, decimals)",
+      "expression": "join(`\"|\"`, decimals)",
       "error": "invalid-type"
     },
     {
-      "expression": "join(`|`, decimals[].to_string(@))",
+      "expression": "join(`\"|\"`, decimals[].to_string(@))",
       "result": "1.01|1.2|-1.5"
     },
     {
-      "expression": "join(`|`, empty_list)",
+      "expression": "join(`\"|\"`, empty_list)",
       "result": ""
     },
     {
@@ -404,27 +404,27 @@
       "result": []
     },
     {
-      "expression": "reverse(``)",
+      "expression": "reverse(`\"\"`)",
       "result": ""
     },
     {
-      "expression": "reverse(`hello world`)",
+      "expression": "reverse(`\"hello world\"`)",
       "result": "dlrow olleh"
     },
     {
-      "expression": "starts_with(str, `S`)",
+      "expression": "starts_with(str, `\"S\"`)",
       "result": true
     },
     {
-      "expression": "starts_with(str, `St`)",
+      "expression": "starts_with(str, `\"St\"`)",
       "result": true
     },
     {
-      "expression": "starts_with(str, `Str`)",
+      "expression": "starts_with(str, `\"Str\"`)",
       "result": true
     },
     {
-      "expression": "starts_with(str, `String`)",
+      "expression": "starts_with(str, `\"String\"`)",
       "result": false
     },
     {
@@ -452,7 +452,7 @@
       "result": 0
     },
     {
-      "expression": "to_array(`foo`)",
+      "expression": "to_array(`\"foo\"`)",
       "result": ["foo"]
     },
     {
@@ -472,7 +472,7 @@
       "result": [false]
     },
     {
-      "expression": "to_string(`foo`)",
+      "expression": "to_string(`\"foo\"`)",
       "result": "foo"
     },
     {

--- a/tests/compliance/functions.json
+++ b/tests/compliance/functions.json
@@ -68,7 +68,7 @@
       "error": "invalid-type"
     },
     {
-      "expression": "avg(`\"abc\"`)",
+      "expression": "avg('abc')",
       "error": "invalid-type"
     },
     {
@@ -100,23 +100,23 @@
       "result": -1
     },
     {
-      "expression": "ceil(`\"string\"`)",
+      "expression": "ceil('string')",
       "error": "invalid-type"
     },
     {
-      "expression": "contains(`\"abc\"`, `\"a\"`)",
+      "expression": "contains('abc', 'a')",
       "result": true
     },
     {
-      "expression": "contains(`\"abc\"`, `\"d\"`)",
+      "expression": "contains('abc', 'd')",
       "result": false
     },
     {
-      "expression": "contains(`false`, `\"d\"`)",
+      "expression": "contains(`false`, 'd')",
       "error": "invalid-type"
     },
     {
-      "expression": "contains(strings, `\"a\"`)",
+      "expression": "contains(strings, 'a')",
       "result": true
     },
     {
@@ -128,23 +128,23 @@
       "result": false
     },
     {
-      "expression": "ends_with(str, `\"r\"`)",
+      "expression": "ends_with(str, 'r')",
       "result": true
     },
     {
-      "expression": "ends_with(str, `\"tr\"`)",
+      "expression": "ends_with(str, 'tr')",
       "result": true
     },
     {
-      "expression": "ends_with(str, `\"Str\"`)",
+      "expression": "ends_with(str, 'Str')",
       "result": true
     },
     {
-      "expression": "ends_with(str, `\"SStr\"`)",
+      "expression": "ends_with(str, 'SStr')",
       "result": false
     },
     {
-      "expression": "ends_with(str, `\"foo\"`)",
+      "expression": "ends_with(str, 'foo')",
       "result": false
     },
     {
@@ -156,7 +156,7 @@
       "result": 1
     },
     {
-      "expression": "floor(`\"string\"`)",
+      "expression": "floor('string')",
       "error": "invalid-type"
     },
     {
@@ -172,11 +172,11 @@
       "error": "invalid-type"
     },
     {
-      "expression": "length(`\"abc\"`)",
+      "expression": "length('abc')",
       "result": 3
     },
     {
-      "expression": "length(`\"\"`)",
+      "expression": "length('')",
       "result": 0
     },
     {
@@ -288,7 +288,7 @@
       "result": "a"
     },
     {
-      "expression": "type(`\"abc\"`)",
+      "expression": "type('abc')",
       "result": "string"
     },
     {
@@ -352,27 +352,27 @@
       "error": "invalid-type"
     },
     {
-      "expression": "join(`\", \"`, strings)",
+      "expression": "join(', ', strings)",
       "result": "a, b, c"
     },
     {
-      "expression": "join(`\", \"`, strings)",
+      "expression": "join(', ', strings)",
       "result": "a, b, c"
     },
     {
-      "expression": "join(`\",\"`, `[\"a\", \"b\"]`)",
+      "expression": "join(',', `[\"a\", \"b\"]`)",
       "result": "a,b"
     },
     {
-      "expression": "join(`\",\"`, `[\"a\", 0]`)",
+      "expression": "join(',', `[\"a\", 0]`)",
       "error": "invalid-type"
     },
     {
-      "expression": "join(`\", \"`, str)",
+      "expression": "join(', ', str)",
       "error": "invalid-type"
     },
     {
-      "expression": "join(`\"|\"`, strings)",
+      "expression": "join('|', strings)",
       "result": "a|b|c"
     },
     {
@@ -380,15 +380,15 @@
       "error": "invalid-type"
     },
     {
-      "expression": "join(`\"|\"`, decimals)",
+      "expression": "join('|', decimals)",
       "error": "invalid-type"
     },
     {
-      "expression": "join(`\"|\"`, decimals[].to_string(@))",
+      "expression": "join('|', decimals[].to_string(@))",
       "result": "1.01|1.2|-1.5"
     },
     {
-      "expression": "join(`\"|\"`, empty_list)",
+      "expression": "join('|', empty_list)",
       "result": ""
     },
     {
@@ -404,27 +404,27 @@
       "result": []
     },
     {
-      "expression": "reverse(`\"\"`)",
+      "expression": "reverse('')",
       "result": ""
     },
     {
-      "expression": "reverse(`\"hello world\"`)",
+      "expression": "reverse('hello world')",
       "result": "dlrow olleh"
     },
     {
-      "expression": "starts_with(str, `\"S\"`)",
+      "expression": "starts_with(str, 'S')",
       "result": true
     },
     {
-      "expression": "starts_with(str, `\"St\"`)",
+      "expression": "starts_with(str, 'St')",
       "result": true
     },
     {
-      "expression": "starts_with(str, `\"Str\"`)",
+      "expression": "starts_with(str, 'Str')",
       "result": true
     },
     {
-      "expression": "starts_with(str, `\"String\"`)",
+      "expression": "starts_with(str, 'String')",
       "result": false
     },
     {
@@ -452,7 +452,7 @@
       "result": 0
     },
     {
-      "expression": "to_array(`\"foo\"`)",
+      "expression": "to_array('foo')",
       "result": ["foo"]
     },
     {
@@ -472,7 +472,7 @@
       "result": [false]
     },
     {
-      "expression": "to_string(`\"foo\"`)",
+      "expression": "to_string('foo')",
       "result": "foo"
     },
     {
@@ -484,19 +484,19 @@
       "result": "[0,1]"
     },
     {
-      "expression": "to_number(`\"1.0\"`)",
+      "expression": "to_number('1.0')",
       "result": 1.0
     },
     {
-      "expression": "to_number(`\"1.1\"`)",
+      "expression": "to_number('1.1')",
       "result": 1.1
     },
     {
-      "expression": "to_number(`\"4\"`)",
+      "expression": "to_number('4')",
       "result": 4
     },
     {
-      "expression": "to_number(`\"notanumber\"`)",
+      "expression": "to_number('notanumber')",
       "result": null
     },
     {

--- a/tests/compliance/literal.json
+++ b/tests/compliance/literal.json
@@ -10,6 +10,11 @@
                 "result": "foo"
             },
             {
+                "comment": "Interpret escaped unicode.",
+                "expression": "`\"\\u03a6\"`",
+                "result": "Φ"
+            },
+            {
                 "expression": "`\"✓\"`",
                 "result": "✓"
             },
@@ -127,6 +132,53 @@
           "comment": "Literal on RHS of subexpr not allowed",
           "expression": "foo.`\"bar\"`",
           "error": "syntax"
+        }
+      ]
+    },
+    {
+      "comment": "Raw String Literals",
+      "given": {},
+      "cases": [
+        {
+          "expression": "'foo'",
+          "result": "foo"
+        },
+        {
+          "expression": "'  foo  '",
+          "result": "  foo  "
+        },
+        {
+          "expression": "'0'",
+          "result": "0"
+        },
+        {
+          "expression": "'newline\n'",
+          "result": "newline\n"
+        },
+        {
+          "expression": "'\n'",
+          "result": "\n"
+        },
+        {
+          "expression": "'✓'",
+	  "result": "✓"
+        },
+        {
+          "expression": "'𝄞'",
+	  "result": "𝄞"
+        },
+        {
+          "expression": "'  [foo]  '",
+          "result": "  [foo]  "
+        },
+        {
+          "expression": "'[foo]'",
+          "result": "[foo]"
+        },
+        {
+          "comment": "Do not interpret escaped unicode.",
+          "expression": "'\\u03a6'",
+          "result": "\\u03a6"
         }
       ]
     }

--- a/tests/compliance/literal.json
+++ b/tests/compliance/literal.json
@@ -6,20 +6,11 @@
         },
         "cases": [
             {
-                "expression": "`foo`",
-                "result": "foo"
-            },
-            {
                 "expression": "`\"foo\"`",
                 "result": "foo"
             },
             {
-                "comment": "Double quotes must be escaped.",
-                "expression": "`foo\\\"quote`",
-                "result": "foo\"quote"
-            },
-            {
-                "expression": "`✓`",
+                "expression": "`\"✓\"`",
                 "result": "✓"
             },
             {
@@ -83,27 +74,22 @@
                 "result": 9
             },
             {
-                "comment": "Escaping a backtick",
-                "expression": "`foo\\`bar`",
-                "result": "foo`bar"
-            },
-            {
                 "comment": "Escaping a backtick in quotes",
                 "expression": "`\"foo\\`bar\"`",
                 "result": "foo`bar"
             },
             {
                 "comment": "Double quote in literal",
-                "expression": "`foo\\\"bar`",
+                "expression": "`\"foo\\\"bar\"`",
                 "result": "foo\"bar"
             },
             {
-                "expression": "`1\\``",
+                "expression": "`\"1\\`\"`",
                 "result": "1`"
             },
             {
                 "comment": "Multiple literal expressions with escapes",
-                "expression": "`\\\\`.{a:`b`}",
+                "expression": "`\"\\\\\"`.{a:`\"b\"`}",
                 "result": {"a": "b"}
             },
             {
@@ -122,5 +108,26 @@
                 "result": 1
             }
         ]
+    },
+    {
+      "comment": "Literals",
+      "given": {"type": "object"},
+      "cases": [
+        {
+          "comment": "Literal with leading whitespace",
+          "expression": "`  {\"foo\": true}`",
+          "result": {"foo": true}
+        },
+        {
+          "comment": "Literal with trailing whitespace",
+          "expression": "`{\"foo\": true}   `",
+          "result": {"foo": true}
+        },
+        {
+          "comment": "Literal on RHS of subexpr not allowed",
+          "expression": "foo.`\"bar\"`",
+          "error": "syntax"
+        }
+      ]
     }
 ]

--- a/tests/compliance/syntax.json
+++ b/tests/compliance/syntax.json
@@ -430,15 +430,15 @@
     "given": {"type": "object"},
     "cases": [
       {
-        "expression": "foo[?bar==`baz`]",
+        "expression": "foo[?bar==`\"baz\"`]",
         "result": null
       },
       {
-        "expression": "foo[? bar == `baz` ]",
+        "expression": "foo[? bar == `\"baz\"` ]",
         "result": null
       },
       {
-        "expression": "foo[ ?bar==`baz`]",
+        "expression": "foo[ ?bar==`\"baz\"`]",
         "error": "syntax"
       },
       {
@@ -510,55 +510,51 @@
     "given": {"type": "object"},
     "cases": [
       {
-        "expression": "bar.`anything`",
-        "error": "syntax"
-      },
-      {
         "expression": "bar.`\"anything\"`",
         "error": "syntax"
       },
       {
-        "expression": "bar.baz.noexists.`literal`",
+        "expression": "bar.baz.noexists.`\"literal\"`",
         "error": "syntax"
       },
       {
         "comment": "Literal wildcard projection",
-        "expression": "foo[*].`literal`",
+        "expression": "foo[*].`\"literal\"`",
         "error": "syntax"
       },
       {
-        "expression": "foo[*].name.`literal`",
+        "expression": "foo[*].name.`\"literal\"`",
         "error": "syntax"
       },
       {
-        "expression": "foo[].name.`literal`",
+        "expression": "foo[].name.`\"literal\"`",
         "error": "syntax"
       },
       {
-        "expression": "foo[].name.`literal`.`subliteral`",
+        "expression": "foo[].name.`\"literal\"`.`\"subliteral\"`",
         "error": "syntax"
       },
       {
         "comment": "Projecting a literal onto an empty list",
-        "expression": "foo[*].name.noexist.`literal`",
+        "expression": "foo[*].name.noexist.`\"literal\"`",
         "error": "syntax"
       },
       {
-        "expression": "foo[].name.noexist.`literal`",
+        "expression": "foo[].name.noexist.`\"literal\"`",
         "error": "syntax"
       },
       {
-        "expression": "twolen[*].`foo`",
+        "expression": "twolen[*].`\"foo\"`",
         "error": "syntax"
       },
       {
         "comment": "Two level projection of a literal",
-        "expression": "twolen[*].threelen[*].`bar`",
+        "expression": "twolen[*].threelen[*].`\"bar\"`",
         "error": "syntax"
       },
       {
         "comment": "Two level flattened projection of a literal",
-        "expression": "twolen[].threelen[].`bar`",
+        "expression": "twolen[].threelen[].`\"bar\"`",
         "error": "syntax"
       }
     ]
@@ -578,31 +574,6 @@
       {
         "expression": "\"\\\\\"",
         "result": null
-      }
-    ]
-  },
-  {
-    "comment": "Literals",
-    "given": {"type": "object"},
-    "cases": [
-      {
-        "expression": "`foo`",
-        "result": "foo"
-      },
-      {
-        "comment": "Literal with leading whitespace",
-        "expression": "`  {\"foo\": true}`",
-        "result": {"foo": true}
-      },
-      {
-        "comment": "Literal with trailing whitespace",
-        "expression": "`{\"foo\": true}   `",
-        "result": {"foo": true}
-      },
-      {
-        "comment": "Literal on RHS of subexpr not allowed",
-        "expression": "foo.`bar`",
-        "error": "syntax"
       }
     ]
   },

--- a/tests/legacy/literal.json
+++ b/tests/legacy/literal.json
@@ -1,0 +1,56 @@
+[
+    {
+        "given": {
+            "foo": [{"name": "a"}, {"name": "b"}],
+            "bar": {"baz": "qux"}
+        },
+        "cases": [
+            {
+                "expression": "`foo`",
+                "result": "foo"
+            },
+            {
+                "comment": "Double quotes must be escaped.",
+                "expression": "`foo\\\"quote`",
+                "result": "foo\"quote"
+            },
+            {
+                "expression": "`✓`",
+                "result": "✓"
+            },
+            {
+                "comment": "Double quote in literal",
+                "expression": "`foo\\\"bar`",
+                "result": "foo\"bar"
+            },
+            {
+                "expression": "`1\\``",
+                "result": "1`"
+            },
+            {
+                "comment": "Multiple literal expressions with escapes",
+                "expression": "`\\\\`.{a:`b`}",
+                "result": {"a": "b"}
+            }
+        ]
+    },
+  {
+    "comment": "Literals",
+    "given": {"type": "object"},
+    "cases": [
+      {
+        "expression": "`foo`",
+        "result": "foo"
+      },
+      {
+        "expression": "`      foo`",
+        "result": "foo"
+      },
+      {
+        "comment": "Literal on RHS of subexpr not allowed",
+        "expression": "foo.`bar`",
+        "error": "syntax"
+      }
+    ]
+  }
+]

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -9,9 +9,9 @@ import jmespath
 from jmespath.visitor import TreeInterpreter
 
 
-TEST_DIR = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)),
-    'compliance')
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+COMPLIANCE_DIR = os.path.join(TEST_DIR, 'compliance')
+LEGACY_DIR = os.path.join(TEST_DIR, 'legacy')
 NOT_SPECIFIED = object()
 TreeInterpreter.MAP_TYPE = OrderedDict
 
@@ -40,6 +40,9 @@ def _walk_files():
         yield os.path.abspath(single_file)
     else:
         for root, dirnames, filenames in os.walk(TEST_DIR):
+            for filename in filenames:
+                yield os.path.join(root, filename)
+        for root, dirnames, filenames in os.walk(LEGACY_DIR):
             for filename in filenames:
                 yield os.path.join(root, filename)
 


### PR DESCRIPTION
The python implementation will still need to support the existing literal syntax for the indefinite future, but the deprecated code path will at least emit a DeprecationWarning.

I've removed all the legacy literal tests out to a separate legacy/ folder that will remain python specific.  Only the tests for `tests/` will be copied over to `jmespath.test`.