### PR TITLE
Fix regression when parsing filters

### DIFF
--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -57,7 +57,7 @@ class Parser(object):
         'or': 5,
         'flatten': 6,
         'star': 20,
-        'filter': 20,
+        'filter': 21,
         'dot': 40,
         'lbrace': 50,
         'lbracket': 55,

--- a/tests/compliance/filters.json
+++ b/tests/compliance/filters.json
@@ -276,6 +276,10 @@
         "result": [[{"foo": 2, "bar": 1}]]
       },
       {
+        "expression": "reservations[*].instances[?bar==`1`]",
+        "result": [[{"foo": 2, "bar": 1}]]
+      },
+      {
         "expression": "reservations[].instances[?bar==`1`][]",
         "result": [{"foo": 2, "bar": 1}]
       }


### PR DESCRIPTION
Filters still need to be higher than a star token,
but less than a dot.