### PR TITLE
No longer using a regex based lexer

### DIFF
--- a/jmespath/lexer.py
+++ b/jmespath/lexer.py
@@ -1,148 +1,278 @@
-import re
+import string
 import warnings
 from json import loads
 
 from jmespath.exceptions import LexerError, EmptyExpressionError
 
 
-class Lexer(object):
-    TOKENS = (
-        r'(?P<number>-?\d+)|'
-        r'(?P<unquoted_identifier>([a-zA-Z_][a-zA-Z_0-9]*))|'
-        r'(?P<quoted_identifier>("(?:\\\\|\\"|[^"])*"))|'
-        r'(?P<string_literal>(\'(?:\\\\|\\\'|[^\'])*\'))|'
-        r'(?P<literal>(`(?:\\\\|\\`|[^`])*`))|'
-        r'(?P<filter>\[\?)|'
-        r'(?P<or>\|\|)|'
-        r'(?P<pipe>\|)|'
-        r'(?P<ne>!=)|'
-        r'(?P<rbrace>\})|'
-        r'(?P<eq>==)|'
-        r'(?P<dot>\.)|'
-        r'(?P<star>\*)|'
-        r'(?P<gte>>=)|'
-        r'(?P<lparen>\()|'
-        r'(?P<lbrace>\{)|'
-        r'(?P<lte><=)|'
-        r'(?P<flatten>\[\])|'
-        r'(?P<rbracket>\])|'
-        r'(?P<lbracket>\[)|'
-        r'(?P<rparen>\))|'
-        r'(?P<comma>,)|'
-        r'(?P<colon>:)|'
-        r'(?P<lt><)|'
-        r'(?P<expref>&)|'
-        r'(?P<gt>>)|'
-        r'(?P<current>@)|'
-        r'(?P<skip>[ \t]+)'
-    )
+VALID_NUMBER = set(string.digits)
+VALID_IDENTIFIER = set(string.ascii_letters + string.digits + '_')
+STATE_IDENTIFIER = 0;
+STATE_NUMBER = 1;
+STATE_SINGLE_CHAR = 2;
+STATE_WHITESPACE = 3;
+STATE_STRING_LITERAL = 4;
+STATE_QUOTED_STRING = 5;
+STATE_JSON_LITERAL = 6;
+STATE_LBRACKET = 7;
+STATE_PIPE = 8;
+STATE_LT = 9;
+STATE_GT = 10;
+STATE_EQ = 11;
+STATE_NOT = 12;
+TRANSITION_TABLE = {
+    '<': STATE_LT,
+    '>': STATE_GT,
+    '=': STATE_EQ,
+    '!': STATE_NOT,
+    '[': STATE_LBRACKET,
+    '|': STATE_PIPE,
+    '`': STATE_JSON_LITERAL,
+    '"': STATE_QUOTED_STRING,
+    "'": STATE_STRING_LITERAL,
+    '-': STATE_NUMBER,
+    '0': STATE_NUMBER,
+    '1': STATE_NUMBER,
+    '2': STATE_NUMBER,
+    '3': STATE_NUMBER,
+    '4': STATE_NUMBER,
+    '5': STATE_NUMBER,
+    '6': STATE_NUMBER,
+    '7': STATE_NUMBER,
+    '8': STATE_NUMBER,
+    '9': STATE_NUMBER,
+    '.': STATE_SINGLE_CHAR,
+    '*': STATE_SINGLE_CHAR,
+    ']': STATE_SINGLE_CHAR,
+    ',': STATE_SINGLE_CHAR,
+    ':': STATE_SINGLE_CHAR,
+    '@': STATE_SINGLE_CHAR,
+    '&': STATE_SINGLE_CHAR,
+    '(': STATE_SINGLE_CHAR,
+    ')': STATE_SINGLE_CHAR,
+    '{': STATE_SINGLE_CHAR,
+    '}': STATE_SINGLE_CHAR,
+    '_': STATE_IDENTIFIER,
+    'A': STATE_IDENTIFIER,
+    'B': STATE_IDENTIFIER,
+    'C': STATE_IDENTIFIER,
+    'D': STATE_IDENTIFIER,
+    'E': STATE_IDENTIFIER,
+    'F': STATE_IDENTIFIER,
+    'G': STATE_IDENTIFIER,
+    'H': STATE_IDENTIFIER,
+    'I': STATE_IDENTIFIER,
+    'J': STATE_IDENTIFIER,
+    'K': STATE_IDENTIFIER,
+    'L': STATE_IDENTIFIER,
+    'M': STATE_IDENTIFIER,
+    'N': STATE_IDENTIFIER,
+    'O': STATE_IDENTIFIER,
+    'P': STATE_IDENTIFIER,
+    'Q': STATE_IDENTIFIER,
+    'R': STATE_IDENTIFIER,
+    'S': STATE_IDENTIFIER,
+    'T': STATE_IDENTIFIER,
+    'U': STATE_IDENTIFIER,
+    'V': STATE_IDENTIFIER,
+    'W': STATE_IDENTIFIER,
+    'X': STATE_IDENTIFIER,
+    'Y': STATE_IDENTIFIER,
+    'Z': STATE_IDENTIFIER,
+    'a': STATE_IDENTIFIER,
+    'b': STATE_IDENTIFIER,
+    'c': STATE_IDENTIFIER,
+    'd': STATE_IDENTIFIER,
+    'e': STATE_IDENTIFIER,
+    'f': STATE_IDENTIFIER,
+    'g': STATE_IDENTIFIER,
+    'h': STATE_IDENTIFIER,
+    'i': STATE_IDENTIFIER,
+    'j': STATE_IDENTIFIER,
+    'k': STATE_IDENTIFIER,
+    'l': STATE_IDENTIFIER,
+    'm': STATE_IDENTIFIER,
+    'n': STATE_IDENTIFIER,
+    'o': STATE_IDENTIFIER,
+    'p': STATE_IDENTIFIER,
+    'q': STATE_IDENTIFIER,
+    'r': STATE_IDENTIFIER,
+    's': STATE_IDENTIFIER,
+    't': STATE_IDENTIFIER,
+    'u': STATE_IDENTIFIER,
+    'v': STATE_IDENTIFIER,
+    'w': STATE_IDENTIFIER,
+    'x': STATE_IDENTIFIER,
+    'y': STATE_IDENTIFIER,
+    'z': STATE_IDENTIFIER,
+    ' ': STATE_WHITESPACE,
+    "\t": STATE_WHITESPACE,
+    "\n": STATE_WHITESPACE,
+    "\r": STATE_WHITESPACE
+}
+SIMPLE_TOKENS = {
+    '.': 'dot',
+    '*': 'star',
+    ']': 'rbracket',
+    ',': 'comma',
+    ':': 'colon',
+    '@': 'current',
+    '&': 'expref',
+    '(': 'lparen',
+    ')': 'rparen',
+    '{': 'lbrace',
+    '}': 'rbrace'
+}
 
-    def __init__(self):
-        self.master_regex = re.compile(self.TOKENS)
 
-    def tokenize(self, expression):
+class Scanner(object):
+    def __init__(self, expression):
         if not expression:
             raise EmptyExpressionError()
-        previous_column = 0
-        for match in self.master_regex.finditer(expression):
-            value = match.group()
-            start = match.start()
-            end = match.end()
-            if match.lastgroup == 'skip':
-                # Ignore whitespace.
-                previous_column = end
-                continue
-            if start != previous_column:
-                bad_value = expression[previous_column:start]
-                # Try to give a good error message.
-                if bad_value == '"':
-                    raise LexerError(
-                        lexer_position=previous_column,
-                        lexer_value=value,
-                        message='Starting quote is missing the ending quote',
-                        expression=expression)
-                raise LexerError(lexer_position=previous_column,
-                                 lexer_value=value,
-                                 message='Unknown character',
-                                 expression=expression)
-            previous_column = end
-            token_type = match.lastgroup
-            handler = getattr(self, '_token_%s' % token_type.lower(), None)
-            if handler is not None:
-                value = handler(value, start, end)
-            yield {'type': token_type, 'value': value,
-                   'start': start, 'end': end}
-        # At the end of the loop make sure we've consumed all the input.
-        # If we haven't then we have unidentified characters.
-        if end != len(expression):
-            msg = "Unknown characters at the end of the expression"
-            raise LexerError(lexer_position=end,
-                             lexer_value='',
-                             message=msg, expression=expression)
+        self.expression = expression
+        self.pos = 0
+        self.chars = list(self.expression)
+        self.len = len(self.expression)
+        self.current = self.chars[self.pos]
+
+    def next(self):
+        if self.pos == self.len - 1:
+            self.current = None
         else:
-            yield {'type': 'eof', 'value': '',
-                   'start': len(expression), 'end': len(expression)}
+            self.pos += 1
+            self.current = self.chars[self.pos]
+        return self.current
 
-    def _token_number(self, value, start, end):
-        return int(value)
+    def in_delimter(self, delimiter):
+        start = self.pos
+        buffer = ''
+        self.next()
+        while self.current != delimiter:
+            if self.current == '\\':
+                buffer += '\\'
+                self.next()
+            if self.current is None:
+                print(buffer)
+                raise LexerError(lexer_position=start,
+                                 lexer_value=self.expression,
+                                 message="Unclosed delimiter: %s" % buffer)
+            buffer += self.current
+            self.next()
+        self.next()
+        return buffer
 
-    def _token_quoted_identifier(self, value, start, end):
+
+class Lexer(object):
+    def tokenize(self, expression):
+        scanner = Scanner(expression)
+        while scanner.current is not None:
+            if not scanner.current in TRANSITION_TABLE:
+                # The current char must be in the transition table to
+                # be valid.
+                yield {'type': 'unknown', 'value': scanner.current,
+                       'start': scanner.pos, 'end': scanner.pos}
+                scanner.next()
+                continue
+            state = TRANSITION_TABLE[scanner.current]
+            if state == STATE_SINGLE_CHAR:
+                yield {'type': SIMPLE_TOKENS[scanner.current],
+                       'value': scanner.current,
+                       'start': scanner.pos, 'end': scanner.pos}
+                scanner.next()
+            elif state == STATE_IDENTIFIER:
+                start = scanner.pos
+                buffer = scanner.current
+                while scanner.next() in VALID_IDENTIFIER:
+                    buffer += scanner.current
+                yield {'type': 'identifier', 'value': buffer,
+                       'start': start, 'end': len(buffer)}
+            elif state == STATE_WHITESPACE:
+                scanner.next()
+            elif state == STATE_LBRACKET:
+                start = scanner.pos
+                next_char = scanner.next()
+                if next_char == ']':
+                    scanner.next()
+                    yield {'type': 'flatten', 'value': '[]',
+                           'start': start, 'end': start + 1}
+                elif next_char == '?':
+                    scanner.next()
+                    yield {'type': 'filter', 'value': '[?',
+                           'start': start, 'end': start + 1}
+                else:
+                    yield {'type': 'lbracket', 'value': '[',
+                           'start': start, 'end': start}
+            elif state == STATE_STRING_LITERAL:
+                yield self._consume_raw_string_literal(scanner)
+            elif state == STATE_PIPE:
+                yield self._match_or_else(scanner, '|', 'or', 'pipe')
+            elif state == STATE_JSON_LITERAL:
+                yield self._consume_literal(scanner)
+            elif state == STATE_NUMBER:
+                start = scanner.pos
+                buffer = scanner.current
+                while scanner.next() in VALID_NUMBER:
+                    buffer += scanner.current
+                yield {'type': 'number', 'value': int(buffer),
+                       'start': start, 'end': len(buffer)}
+            elif state == STATE_QUOTED_STRING:
+                yield self._consume_quoted_identifier(scanner)
+            elif state == STATE_LT:
+                yield self._match_or_else(scanner, '=', 'lte', 'lt')
+            elif state == STATE_GT:
+                yield self._match_or_else(scanner, '=', 'gte', 'gt')
+            elif state == STATE_EQ:
+                yield self._match_or_else(scanner, '=', 'eq', 'unknown')
+            elif state == STATE_NOT:
+                yield self._match_or_else(scanner, '=', 'ne', 'unknown')
+        yield {'type': 'eof', 'value': '',
+               'start': len(expression), 'end': len(expression)}
+
+    def _consume_literal(self, scanner):
+        start = scanner.pos
+        lexeme = scanner.in_delimter('`')
         try:
-            return loads(value)
+            # Assume it is valid JSON and attempt to parse.
+            parsed_json = loads(lexeme)
+        except ValueError:
+            try:
+                # Invalid JSON values should be converted to quoted
+                # JSON strings during the JEP-12 deprecation period.
+                parsed_json = loads('"%s"' % lexeme)
+                warnings.warn("deprecated string literal syntax",
+                              PendingDeprecationWarning)
+            except ValueError:
+                raise LexerError(lexer_position=start,
+                                 lexer_value=lexeme,
+                                 message="Bad token %s" % value)
+        return {'type': 'literal', 'value': parsed_json,
+                'start': start, 'end': len(lexeme)}
+
+    def _consume_quoted_identifier(self, scanner):
+        start = scanner.pos
+        lexeme = scanner.in_delimter('"')
+        try:
+            return {'type': 'identifier', 'value': loads(lexeme),
+                    'start': start, 'end': len(lexeme)}
         except ValueError as e:
             error_message = str(e).split(':')[0]
             raise LexerError(lexer_position=start,
-                             lexer_value=value,
+                             lexer_value=lexeme,
                              message=error_message)
 
-    def _token_string_literal(self, value, start, end):
-        return value[1:-1]
+    def _consume_raw_string_literal(self, scanner):
+        start = scanner.pos
+        lexeme = scanner.in_delimter("'")
+        return {'type': 'literal', 'value': lexeme,
+                'start': start, 'end': len(lexeme)}
 
-    def _token_literal(self, value, start, end):
-        actual_value = value[1:-1]
-        actual_value = actual_value.replace('\\`', '`').lstrip()
-        # First, if it looks like JSON then we parse it as
-        # JSON and any json parsing errors propogate as lexing
-        # errors.
-        if self._looks_like_json(actual_value):
-            try:
-                return loads(actual_value)
-            except ValueError:
-                raise LexerError(lexer_position=start,
-                                 lexer_value=value,
-                                 message="Bad token %s" % value)
-        else:
-            potential_value = '"%s"' % actual_value
-            try:
-                # There's a shortcut syntax where string literals
-                # don't have to be quoted.  This is only true if the
-                # string doesn't start with chars that could start a valid
-                # JSON value.
-                value = loads(potential_value)
-                warnings.warn("deprecated string literal syntax",
-                              PendingDeprecationWarning)
-                return value
-            except ValueError:
-                raise LexerError(lexer_position=start,
-                                 lexer_value=value,
-                                 message="Bad token %s" % value)
-
-    def _looks_like_json(self, value):
-        # Figure out if the string "value" starts with something
-        # that looks like json.
-        if not value:
-            return False
-        elif value[0] in ['"', '{', '[']:
-            return True
-        elif value in ['true', 'false', 'null']:
-            return True
-        elif value[0] in ['-', '0', '1', '2', '3', '4', '5',
-                          '6', '7', '8', '9']:
-            # Then this is JSON, return True.
-            try:
-                loads(value)
-                return True
-            except ValueError:
-                return False
-        else:
-            return False
+    def _match_or_else(self, scanner, expected, match_type, else_type):
+        start = scanner.pos
+        current = scanner.current
+        next_char = scanner.next()
+        if next_char == expected:
+            scanner.next()
+            return {'type': match_type, 'value': current + next_char,
+                    'start': start, 'end': start + 1}
+        return {'type': else_type, 'value': current,
+                'start': start, 'end': start}

--- a/jmespath/lexer.py
+++ b/jmespath/lexer.py
@@ -5,43 +5,6 @@ from json import loads
 from jmespath.exceptions import LexerError, EmptyExpressionError
 
 
-class Scanner(object):
-    def __init__(self, expression):
-        if not expression:
-            raise EmptyExpressionError()
-        self.expression = expression
-        self.pos = 0
-        self.chars = list(self.expression)
-        self.len = len(self.expression)
-        self.current = self.chars[self.pos]
-
-    def next(self):
-        if self.pos == self.len - 1:
-            self.current = None
-        else:
-            self.pos += 1
-            self.current = self.chars[self.pos]
-        return self.current
-
-    def in_delimiter(self, delimiter):
-        start = self.pos
-        buff = ''
-        self.next()
-        while self.current != delimiter:
-            if self.current == '\\':
-                buff += '\\'
-                self.next()
-            if self.current is None:
-                raise LexerError(lexer_position=start,
-                                 lexer_value=self.expression,
-                                 message="Unclosed %s delimiter" % delimiter)
-            buff += self.current
-            self.next()
-        # Skip the closing delimiter.
-        self.next()
-        return buff
-
-
 class Lexer(object):
     START_IDENTIFIER = set(string.ascii_letters + '_')
     VALID_IDENTIFIER = set(string.ascii_letters + string.digits + '_')
@@ -63,69 +26,104 @@ class Lexer(object):
     }
 
     def tokenize(self, expression):
-        scanner = Scanner(expression)
-        while scanner.current is not None:
-            if scanner.current in self.SIMPLE_TOKENS:
-                yield {'type': self.SIMPLE_TOKENS[scanner.current],
-                       'value': scanner.current,
-                       'start': scanner.pos, 'end': scanner.pos + 1}
-                scanner.next()
-            elif scanner.current in self.START_IDENTIFIER:
-                start = scanner.pos
-                buff = scanner.current
-                while scanner.next() in self.VALID_IDENTIFIER:
-                    buff += scanner.current
+        self._init_expr(expression)
+        while self._current is not None:
+            if self._current in self.SIMPLE_TOKENS:
+                yield {'type': self.SIMPLE_TOKENS[self._current],
+                       'value': self._current,
+                       'start': self._pos, 'end': self._pos + 1}
+                self._next()
+            elif self._current in self.START_IDENTIFIER:
+                start = self._pos
+                buff = self._current
+                while self._next() in self.VALID_IDENTIFIER:
+                    buff += self._current
                 yield {'type': 'unquoted_identifier', 'value': buff,
                        'start': start, 'end': start + len(buff)}
-            elif scanner.current in self.WHITESPACE:
-                scanner.next()
-            elif scanner.current == '[':
-                start = scanner.pos
-                next_char = scanner.next()
+            elif self._current in self.WHITESPACE:
+                self._next()
+            elif self._current == '[':
+                start = self._pos
+                next_char = self._next()
                 if next_char == ']':
-                    scanner.next()
+                    self._next()
                     yield {'type': 'flatten', 'value': '[]',
                            'start': start, 'end': start + 2}
                 elif next_char == '?':
-                    scanner.next()
+                    self._next()
                     yield {'type': 'filter', 'value': '[?',
                            'start': start, 'end': start + 2}
                 else:
                     yield {'type': 'lbracket', 'value': '[',
                            'start': start, 'end': start + 1}
-            elif scanner.current == "'":
-                yield self._consume_raw_string_literal(scanner)
-            elif scanner.current == '|':
-                yield self._match_or_else(scanner, '|', 'or', 'pipe')
-            elif scanner.current == '`':
-                yield self._consume_literal(scanner)
-            elif scanner.current in self.START_NUMBER:
-                start = scanner.pos
-                buff = scanner.current
-                while scanner.next() in self.VALID_NUMBER:
-                    buff += scanner.current
+            elif self._current == "'":
+                yield self._consume_raw_string_literal()
+            elif self._current == '|':
+                yield self._match_or_else('|', 'or', 'pipe')
+            elif self._current == '`':
+                yield self._consume_literal()
+            elif self._current in self.START_NUMBER:
+                start = self._pos
+                buff = self._current
+                while self._next() in self.VALID_NUMBER:
+                    buff += self._current
                 yield {'type': 'number', 'value': int(buff),
                        'start': start, 'end': start + len(buff)}
-            elif scanner.current == '"':
-                yield self._consume_quoted_identifier(scanner)
-            elif scanner.current == '<':
-                yield self._match_or_else(scanner, '=', 'lte', 'lt')
-            elif scanner.current == '>':
-                yield self._match_or_else(scanner, '=', 'gte', 'gt')
-            elif scanner.current == '!':
-                yield self._match_or_else(scanner, '=', 'ne', 'unknown')
-            elif scanner.current == '=':
-                yield self._match_or_else(scanner, '=', 'eq', 'unknown')
+            elif self._current == '"':
+                yield self._consume_quoted_identifier()
+            elif self._current == '<':
+                yield self._match_or_else('=', 'lte', 'lt')
+            elif self._current == '>':
+                yield self._match_or_else('=', 'gte', 'gt')
+            elif self._current == '!':
+                yield self._match_or_else('=', 'ne', 'unknown')
+            elif self._current == '=':
+                yield self._match_or_else('=', 'eq', 'unknown')
             else:
-                raise LexerError(lexer_position=scanner.pos,
-                                 lexer_value=scanner.current,
-                                 message="Unknown token %s" % scanner.current)
+                raise LexerError(lexer_position=self._pos,
+                                 lexer_value=self._current,
+                                 message="Unknown token %s" % self._current)
         yield {'type': 'eof', 'value': '',
-               'start': len(expression), 'end': len(expression)}
+               'start': self._len, 'end': self._len}
 
-    def _consume_literal(self, scanner):
-        start = scanner.pos
-        lexeme = scanner.in_delimiter('`')
+    def _init_expr(self, expression):
+        if not expression:
+            raise EmptyExpressionError()
+        self._pos = 0
+        self._expression = expression
+        self._chars = list(self._expression)
+        self._current = self._chars[self._pos]
+        self._len = len(self._expression)
+
+    def _next(self):
+        if self._pos == self._len - 1:
+            self._current = None
+        else:
+            self._pos += 1
+            self._current = self._chars[self._pos]
+        return self._current
+
+    def _in_delimiter(self, delimiter):
+        start = self._pos
+        buff = ''
+        self._next()
+        while self._current != delimiter:
+            if self._current == '\\':
+                buff += '\\'
+                self._next()
+            if self._current is None:
+                raise LexerError(lexer_position=start,
+                                 lexer_value=self._expression,
+                                 message="Unclosed %s delimiter" % delimiter)
+            buff += self._current
+            self._next()
+        # Skip the closing delimiter.
+        self._next()
+        return buff
+
+    def _consume_literal(self):
+        start = self._pos
+        lexeme = self._in_delimiter('`')
         lexeme = lexeme.replace('\\`', '`')
         try:
             # Assume it is valid JSON and attempt to parse.
@@ -139,17 +137,17 @@ class Lexer(object):
                               PendingDeprecationWarning)
             except ValueError:
                 raise LexerError(lexer_position=start,
-                                 lexer_value=lexeme,
+                                 lexer_value=self._expression,
                                  message="Bad token %s" % lexeme)
-        token_len = scanner.pos - start
+        token_len = self._pos - start
         return {'type': 'literal', 'value': parsed_json,
                 'start': start, 'end': token_len}
 
-    def _consume_quoted_identifier(self, scanner):
-        start = scanner.pos
-        lexeme = '"' + scanner.in_delimiter('"') + '"'
+    def _consume_quoted_identifier(self):
+        start = self._pos
+        lexeme = '"' + self._in_delimiter('"') + '"'
         try:
-            token_len = scanner.pos - start
+            token_len = self._pos - start
             return {'type': 'quoted_identifier', 'value': loads(lexeme),
                     'start': start, 'end': token_len}
         except ValueError as e:
@@ -158,19 +156,19 @@ class Lexer(object):
                              lexer_value=lexeme,
                              message=error_message)
 
-    def _consume_raw_string_literal(self, scanner):
-        start = scanner.pos
-        lexeme = scanner.in_delimiter("'")
-        token_len = scanner.pos - start
+    def _consume_raw_string_literal(self):
+        start = self._pos
+        lexeme = self._in_delimiter("'")
+        token_len = self._pos - start
         return {'type': 'literal', 'value': lexeme,
                 'start': start, 'end': token_len}
 
-    def _match_or_else(self, scanner, expected, match_type, else_type):
-        start = scanner.pos
-        current = scanner.current
-        next_char = scanner.next()
+    def _match_or_else(self, expected, match_type, else_type):
+        start = self._pos
+        current = self._current
+        next_char = self._next()
         if next_char == expected:
-            scanner.next()
+            self._next()
             return {'type': match_type, 'value': current + next_char,
                     'start': start, 'end': start + 1}
         return {'type': else_type, 'value': current,

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -132,6 +132,17 @@ class TestRegexLexer(unittest.TestCase):
              ]
         )
 
+    def test_adds_quotes_when_invalid_json(self):
+        tokens = list(self.lexer.tokenize('`{{}`'))
+        self.assertEqual(
+            tokens,
+            [{'type': 'literal', 'value': '{{}',
+              'start': 0, 'end': 4},
+             {'type': 'eof', 'value': '',
+              'start': 5, 'end': 5}
+             ]
+        )
+
     def test_unknown_character(self):
         with self.assertRaises(LexerError):
             tokens = list(self.lexer.tokenize('foo[0^]'))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -144,16 +144,10 @@ class TestErrorMessages(unittest.TestCase):
     def test_bad_lexer_values(self):
         error_message = (
             'Bad jmespath expression: '
-            'Starting quote is missing the ending quote:\n'
+            'Unclosed " delimiter:\n'
             'foo."bar\n'
             '    ^')
         self.assert_error_message('foo."bar', error_message,
-                                  exception=exceptions.LexerError)
-
-    def test_bad_lexer_literal_value_with_json_object(self):
-        error_message = ('Bad jmespath expression: '
-                         'Bad token `{{}`:\n`{{}`\n^')
-        self.assert_error_message('`{{}`', error_message,
                                   exception=exceptions.LexerError)
 
     def test_bad_unicode_string(self):


### PR DESCRIPTION
This pull request updates jmespath.py to no longer use a regex based lexer, resulting in a lexer that is 58% faster than the current lexer (based on the performance tests).

Results of running the perf tests on the current develop branch:

```
lex_time: 0.00900ms, parse_time: 0.01900ms, search_time: 0.00500ms combined_time: 0.02500ms name: single_expression
lex_time: 0.01700ms, parse_time: 0.03300ms, search_time: 0.00800ms combined_time: 0.04200ms name: single_dot_expression
lex_time: 0.02400ms, parse_time: 0.04600ms, search_time: 0.00900ms combined_time: 0.05700ms name: double_dot_expression
lex_time: 0.03100ms, parse_time: 0.06000ms, search_time: 0.01300ms combined_time: 0.07300ms name: dot_no_match
lex_time: 0.07400ms, parse_time: 0.13700ms, search_time: 0.01600ms combined_time: 0.15500ms name: deep_nesting_10
lex_time: 0.36300ms, parse_time: 0.64200ms, search_time: 0.05500ms combined_time: 0.70100ms name: deep_nesting_50
lex_time: 0.35700ms, parse_time: 0.60600ms, search_time: 0.10800ms combined_time: 0.71700ms name: deep_nesting_50_pipe
lex_time: 0.64200ms, parse_time: 0.91400ms, search_time: 0.06400ms combined_time: 0.98300ms name: deep_nesting_50_index
lex_time: 1.88600ms, parse_time: 3.06100ms, search_time: 0.00700ms combined_time: 3.07600ms name: deep_projection_104
lex_time: 0.03800ms, parse_time: 0.06400ms, search_time: 0.16700ms combined_time: 0.24000ms name: min sort with slice
lex_time: 0.03800ms, parse_time: 0.06500ms, search_time: 0.16800ms combined_time: 0.24100ms name: max sort with slice
lex_time: 0.04700ms, parse_time: 0.07900ms, search_time: 0.01800ms combined_time: 0.09900ms name: multi_wildcard_field
lex_time: 0.04900ms, parse_time: 0.08200ms, search_time: 0.02100ms combined_time: 0.10600ms name: wildcard_with_index
lex_time: 0.02800ms, parse_time: 0.05000ms, search_time: 0.01200ms combined_time: 0.06400ms name: wildcard_with_field_match
lex_time: 0.02800ms, parse_time: 0.04900ms, search_time: 0.01200ms combined_time: 0.06400ms name: wildcard_with_field_match2
```

Results when running using this PR:

```
lex_time: 0.00900ms, parse_time: 0.01600ms, search_time: 0.00500ms combined_time: 0.02100ms name: single_expression
lex_time: 0.01400ms, parse_time: 0.02700ms, search_time: 0.00800ms combined_time: 0.03600ms name: single_dot_expression
lex_time: 0.01900ms, parse_time: 0.03800ms, search_time: 0.00900ms combined_time: 0.04800ms name: double_dot_expression
lex_time: 0.02400ms, parse_time: 0.04900ms, search_time: 0.01200ms combined_time: 0.06200ms name: dot_no_match
lex_time: 0.06000ms, parse_time: 0.11300ms, search_time: 0.01600ms combined_time: 0.13300ms name: deep_nesting_10
lex_time: 0.25700ms, parse_time: 0.52300ms, search_time: 0.05600ms combined_time: 0.58100ms name: deep_nesting_50
lex_time: 0.29800ms, parse_time: 0.53000ms, search_time: 0.10700ms combined_time: 0.64100ms name: deep_nesting_50_pipe
lex_time: 0.41400ms, parse_time: 0.68300ms, search_time: 0.06500ms combined_time: 0.74900ms name: deep_nesting_50_index
lex_time: 0.87200ms, parse_time: 1.95900ms, search_time: 0.00700ms combined_time: 1.96900ms name: deep_projection_104
lex_time: 0.02400ms, parse_time: 0.04700ms, search_time: 0.16700ms combined_time: 0.21900ms name: min sort with slice
lex_time: 0.02500ms, parse_time: 0.04800ms, search_time: 0.16700ms combined_time: 0.22100ms name: max sort with slice
lex_time: 0.03000ms, parse_time: 0.05700ms, search_time: 0.01900ms combined_time: 0.07700ms name: multi_wildcard_field
lex_time: 0.03300ms, parse_time: 0.06200ms, search_time: 0.02100ms combined_time: 0.08600ms name: wildcard_with_index
lex_time: 0.01900ms, parse_time: 0.03600ms, search_time: 0.01200ms combined_time: 0.05000ms name: wildcard_with_field_match
lex_time: 0.02300ms, parse_time: 0.03900ms, search_time: 0.01200ms combined_time: 0.05300ms name: wildcard_with_field_match2
```

As you can see, the performance improves modestly for smaller expressions, but vastly improves for things like deep_projection_104.