### PR TITLE
Add support for custom functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,85 @@ of your dict keys.  To do this you can use either of these options:
     ...               jmespath.Options(dict_cls=collections.OrderedDict))
 
 
+Custom Functions
+~~~~~~~~~~~~~~~~
+
+The JMESPath language has numerous
+`built-in functions
+<http://jmespath.org/specification.html#built-in-functions>`__, but it is
+also possible to add your own custom functions.  Keep in mind that
+custom function support in jmespath.py is experimental and the API may
+change based on feedback.
+
+**If you have a custom function that you've found useful, consider submitting
+it to jmespath.site and propose that it be added to the JMESPath language.**
+You can submit proposals
+`here <https://github.com/jmespath/jmespath.site/issues>`__.
+
+To create custom functions:
+
+* Create a subclass of ``jmespath.functions.Functions``.
+* Create a method with the name ``_func_<your function name>``.
+* Apply the ``jmespath.functions.signature`` decorator that indicates
+  the expected types of the function arguments.
+* Provide an instance of your subclass in a ``jmespath.Options`` object.
+
+Below are a few examples:
+
+.. code:: python
+
+    import jmespath
+    from jmespath import functions
+
+    # 1. Create a subclass of functions.Functions.
+    #    The function.Functions base class has logic
+    #    that introspects all of its methods and automatically
+    #    registers your custom functions in its function table.
+    class CustomFunctions(functions.Functions):
+
+        # 2 and 3.  Create a function that starts with _func_
+        # and decorate it with @signature which indicates its
+        # expected types.
+        # In this example, we're creating a jmespath function
+        # called "unique_letters" that accepts a single argument
+        # with an expected type "string".
+        @functions.signature({'types': ['string']})
+        def _func_unique_letters(self, s):
+            # Given a string s, return a sorted
+            # string of unique letters: 'ccbbadd' ->  'abcd'
+            return ''.join(sorted(set(s)))
+
+        # Here's another example.  This is creating
+        # a jmespath function called "my_add" that expects
+        # two arguments, both of which should be of type number.
+        @functions.signature({'types': ['number']}, {'types': ['number']})
+        def _func_my_add(self, x, y):
+            return x + y
+
+    # 4. Provide an instance of your subclass in a Options object.
+    options = jmespath.Options(custom_functions=CustomFunctions())
+
+    # Provide this value to jmespath.search:
+    # This will print 3
+    print(
+        jmespath.search(
+            'my_add(`1`, `2`)', {}, options=options)
+    )
+
+    # This will print "abcd"
+    print(
+        jmespath.search(
+            'foo.bar | unique_letters(@)',
+            {'foo': {'bar': 'ccbbadd'}},
+            options=options)
+    )
+
+Again, if you come up with useful functions that you think make
+sense in the JMESPath language (and make sense to implement in all
+JMESPath libraries, not just python), please let us know at
+`jmespath.site <https://github.com/jmespath/jmespath.site/issues>`__.
+
+
 Specification
 =============
 

--- a/jmespath/compat.py
+++ b/jmespath/compat.py
@@ -3,6 +3,15 @@ import inspect
 
 PY2 = sys.version_info[0] == 2
 
+
+def with_metaclass(meta, *bases):
+    # Taken from flask/six.
+    class metaclass(meta):
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+    return type.__new__(metaclass, 'temporary_class', (), {})
+
+
 if PY2:
     text_type = unicode
     string_type = basestring

--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -44,17 +44,17 @@ def populate_function_table(cls):
     return cls
 
 
-def builtin_function(*arguments):
-    def _record_arity(func):
+def signature(*arguments):
+    def _record_signature(func):
         func.signature = arguments
         return func
-    return _record_arity
+    return _record_signature
 
 
 @populate_function_table
 class RuntimeFunctions(object):
     # The built in functions are automatically populated in the FUNCTION_TABLE
-    # using the @builtin_function decorator on methods defined in this class.
+    # using the @signature decorator on methods defined in this class.
 
     FUNCTION_TABLE = {
     }
@@ -151,28 +151,28 @@ class RuntimeFunctions(object):
                     raise exceptions.JMESPathTypeError(
                         function_name, element, actual_typename, types)
 
-    @builtin_function({'types': ['number']})
+    @signature({'types': ['number']})
     def _func_abs(self, arg):
         return abs(arg)
 
-    @builtin_function({'types': ['array-number']})
+    @signature({'types': ['array-number']})
     def _func_avg(self, arg):
         return sum(arg) / float(len(arg))
 
-    @builtin_function({'types': [], 'variadic': True})
+    @signature({'types': [], 'variadic': True})
     def _func_not_null(self, *arguments):
         for argument in arguments:
             if argument is not None:
                 return argument
 
-    @builtin_function({'types': []})
+    @signature({'types': []})
     def _func_to_array(self, arg):
         if isinstance(arg, list):
             return arg
         else:
             return [arg]
 
-    @builtin_function({'types': []})
+    @signature({'types': []})
     def _func_to_string(self, arg):
         if isinstance(arg, STRING_TYPE):
             return arg
@@ -180,7 +180,7 @@ class RuntimeFunctions(object):
             return json.dumps(arg, separators=(',', ':'),
                               default=str)
 
-    @builtin_function({'types': []})
+    @signature({'types': []})
     def _func_to_number(self, arg):
         if isinstance(arg, (list, dict, bool)):
             return None
@@ -197,88 +197,88 @@ class RuntimeFunctions(object):
             except ValueError:
                 return None
 
-    @builtin_function({'types': ['array', 'string']}, {'types': []})
+    @signature({'types': ['array', 'string']}, {'types': []})
     def _func_contains(self, subject, search):
         return search in subject
 
-    @builtin_function({'types': ['string', 'array', 'object']})
+    @signature({'types': ['string', 'array', 'object']})
     def _func_length(self, arg):
         return len(arg)
 
-    @builtin_function({'types': ['string']}, {'types': ['string']})
+    @signature({'types': ['string']}, {'types': ['string']})
     def _func_ends_with(self, search, suffix):
         return search.endswith(suffix)
 
-    @builtin_function({'types': ['string']}, {'types': ['string']})
+    @signature({'types': ['string']}, {'types': ['string']})
     def _func_starts_with(self, search, suffix):
         return search.startswith(suffix)
 
-    @builtin_function({'types': ['array', 'string']})
+    @signature({'types': ['array', 'string']})
     def _func_reverse(self, arg):
         if isinstance(arg, STRING_TYPE):
             return arg[::-1]
         else:
             return list(reversed(arg))
 
-    @builtin_function({"types": ['number']})
+    @signature({"types": ['number']})
     def _func_ceil(self, arg):
         return math.ceil(arg)
 
-    @builtin_function({"types": ['number']})
+    @signature({"types": ['number']})
     def _func_floor(self, arg):
         return math.floor(arg)
 
-    @builtin_function({"types": ['string']}, {"types": ['array-string']})
+    @signature({"types": ['string']}, {"types": ['array-string']})
     def _func_join(self, separator, array):
         return separator.join(array)
 
-    @builtin_function({'types': ['expref']}, {'types': ['array']})
+    @signature({'types': ['expref']}, {'types': ['array']})
     def _func_map(self, expref, arg):
         result = []
         for element in arg:
             result.append(expref.visit(expref.expression, element))
         return result
 
-    @builtin_function({"types": ['array-number', 'array-string']})
+    @signature({"types": ['array-number', 'array-string']})
     def _func_max(self, arg):
         if arg:
             return max(arg)
         else:
             return None
 
-    @builtin_function({"types": ["object"], "variadic": True})
+    @signature({"types": ["object"], "variadic": True})
     def _func_merge(self, *arguments):
         merged = {}
         for arg in arguments:
             merged.update(arg)
         return merged
 
-    @builtin_function({"types": ['array-number', 'array-string']})
+    @signature({"types": ['array-number', 'array-string']})
     def _func_min(self, arg):
         if arg:
             return min(arg)
         else:
             return None
 
-    @builtin_function({"types": ['array-string', 'array-number']})
+    @signature({"types": ['array-string', 'array-number']})
     def _func_sort(self, arg):
         return list(sorted(arg))
 
-    @builtin_function({"types": ['array-number']})
+    @signature({"types": ['array-number']})
     def _func_sum(self, arg):
         return sum(arg)
 
-    @builtin_function({"types": ['object']})
+    @signature({"types": ['object']})
     def _func_keys(self, arg):
         # To be consistent with .values()
         # should we also return the indices of a list?
         return list(arg.keys())
 
-    @builtin_function({"types": ['object']})
+    @signature({"types": ['object']})
     def _func_values(self, arg):
         return list(arg.values())
 
-    @builtin_function({'types': []})
+    @signature({'types': []})
     def _func_type(self, arg):
         if isinstance(arg, STRING_TYPE):
             return "string"
@@ -293,7 +293,7 @@ class RuntimeFunctions(object):
         elif arg is None:
             return "null"
 
-    @builtin_function({'types': ['array']}, {'types': ['expref']})
+    @signature({'types': ['array']}, {'types': ['expref']})
     def _func_sort_by(self, array, expref):
         if not array:
             return array
@@ -313,14 +313,14 @@ class RuntimeFunctions(object):
                                         'sort_by')
         return list(sorted(array, key=keyfunc))
 
-    @builtin_function({'types': ['array']}, {'types': ['expref']})
+    @signature({'types': ['array']}, {'types': ['expref']})
     def _func_min_by(self, array, expref):
         keyfunc = self._create_key_func(expref,
                                         ['number', 'string'],
                                         'min_by')
         return min(array, key=keyfunc)
 
-    @builtin_function({'types': ['array']}, {'types': ['expref']})
+    @signature({'types': ['array']}, {'types': ['expref']})
     def _func_max_by(self, array, expref):
         keyfunc = self._create_key_func(expref,
                                         ['number', 'string'],

--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -35,7 +35,7 @@ def _is_special_integer_case(x, y):
 
 class Options(object):
     """Options to control how a JMESPath function is evaluated."""
-    def __init__(self, dict_cls):
+    def __init__(self, dict_cls=None, custom_functions=None):
         #: The class to use when creating a dict.  The interpreter
         #  may create dictionaries during the evalution of a JMESPath
         #  expression.  For example, a multi-select hash will
@@ -45,6 +45,7 @@ class Options(object):
         #  want to set a collections.OrderedDict so that you can
         #  have predictible key ordering.
         self.dict_cls = dict_cls
+        self.custom_functions = custom_functions
 
 
 class _Expression(object):
@@ -87,11 +88,16 @@ class TreeInterpreter(Visitor):
 
     def __init__(self, options=None):
         super(TreeInterpreter, self).__init__()
-        self._options = options
         self._dict_cls = self.MAP_TYPE
-        if options is not None and options.dict_cls is not None:
+        if options is None:
+            options = Options()
+        self._options = options
+        if options.dict_cls is not None:
             self._dict_cls = self._options.dict_cls
-        self._functions = functions.RuntimeFunctions()
+        if options.custom_functions is not None:
+            self._functions = self._options.custom_functions
+        else:
+            self._functions = functions.RuntimeFunctions()
 
     def default_visit(self, node, *args, **kwargs):
         raise NotImplementedError(node['type'])

--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -48,8 +48,12 @@ class Options(object):
 
 
 class _Expression(object):
-    def __init__(self, expression):
+    def __init__(self, expression, interpreter):
         self.expression = expression
+        self.interpreter = interpreter
+
+    def visit(self, node, *args, **kwargs):
+        return self.interpreter.visit(node, *args, **kwargs)
 
 
 class Visitor(object):
@@ -88,10 +92,6 @@ class TreeInterpreter(Visitor):
         if options is not None and options.dict_cls is not None:
             self._dict_cls = self._options.dict_cls
         self._functions = functions.RuntimeFunctions()
-        # Note that .interpreter is a property that uses
-        # a weakref so that the cyclic reference can be
-        # properly freed.
-        self._functions.interpreter = self
 
     def default_visit(self, node, *args, **kwargs):
         raise NotImplementedError(node['type'])
@@ -119,7 +119,7 @@ class TreeInterpreter(Visitor):
         return value
 
     def visit_expref(self, node, value):
-        return _Expression(node['children'][0])
+        return _Expression(node['children'][0], self)
 
     def visit_function_expression(self, node, value):
         resolved_args = []

--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -97,7 +97,7 @@ class TreeInterpreter(Visitor):
         if options.custom_functions is not None:
             self._functions = self._options.custom_functions
         else:
-            self._functions = functions.RuntimeFunctions()
+            self._functions = functions.Functions()
 
     def default_visit(self, node, *args, **kwargs):
         raise NotImplementedError(node['type'])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,6 +1,7 @@
 from tests import unittest, OrderedDict
 
 import jmespath
+import jmespath.functions
 
 
 class TestSearchOptions(unittest.TestCase):
@@ -10,3 +11,28 @@ class TestSearchOptions(unittest.TestCase):
             {'c': 'c', 'b': 'b', 'a': 'a', 'd': 'd'},
             options=jmespath.Options(dict_cls=OrderedDict))
         self.assertEqual(result, ['a', 'b', 'c'])
+
+    def test_can_provide_custom_functions(self):
+        class CustomFunctions(jmespath.functions.Functions):
+            @jmespath.functions.signature(
+                {'types': ['number']},
+                {'types': ['number']})
+            def _func_custom_add(self, x, y):
+                return x + y
+
+            @jmespath.functions.signature(
+                {'types': ['number']},
+                {'types': ['number']})
+            def _func_my_subtract(self, x, y):
+                return x - y
+
+
+        options = jmespath.Options(custom_functions=CustomFunctions())
+        self.assertEqual(
+            jmespath.search('custom_add(`1`, `2`)', {}, options=options),
+            3
+        )
+        self.assertEqual(
+            jmespath.search('my_subtract(`10`, `3`)', {}, options=options),
+            7
+        )


### PR DESCRIPTION
This adds support for custom functions.  It has these changes:

* Add `custom_functions` to the `Options` class.  This is how you can provide custom functions to use.
* Remove instance variable of `interpreter` in the `Functions` class.  This was originally added to invoke `exprefs`, but the cyclic dependency between interpreter and functions made initialization awkward.  Each expref now has a reference to the interpreter.  This may need some rethinking if other backends besides a tree interpreter are added.
* Remove the need for a class decorator to populate the function table in the `Functions` class.  Instead this has all been moved out into a metaclass.  The benefit here is that you can subclass from this base class and the `FUNCTION_TABLE` will be automatically populated for you.  This makes the extension API more straightforward.

I've added an example in the README (and a testcase) that shows how you can add custom functions.

Closes #100 