### PR TITLE
Add hypothesis tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ nosetests.xml
 
 *.out
 _build
+
+.hypothesis

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ install:
   - pip install -r requirements.txt
   - python setup.py bdist_wheel
   - pip install dist/*.whl
-script: cd tests/ && nosetests --with-coverage --cover-package jmespath .
+script:
+  - cd tests/ && nosetests --with-coverage --cover-package jmespath .
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then JP_MAX_EXAMPLES=10000 nosetests test_hypothesis.py; fi
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ install:
   - pip install dist/*.whl
 script:
   - cd tests/ && nosetests --with-coverage --cover-package jmespath .
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then JP_MAX_EXAMPLES=10000 nosetests test_hypothesis.py; fi
+  - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then JP_MAX_EXAMPLES=10000 nosetests ../extra/test_hypothesis.py; fi
 after_success:
   - codecov

--- a/extra/test_hypothesis.py
+++ b/extra/test_hypothesis.py
@@ -14,30 +14,22 @@ from jmespath import parser
 from jmespath import exceptions
 
 
-MAX_EXAMPLES = int(os.environ.get('JP_MAX_EXAMPLES', 100))
-if sys.version_info[:2] != (2, 6):
-    RANDOM_JSON = st.recursive(
-        st.floats() | st.booleans() | st.text() | st.none(),
-        lambda children: st.lists(children) | st.dictionaries(st.text(), children)
-    )
-else:
-    # hypothesis doesn't work on py26 and the prevous definition of
-    # RANDOM_JSON would throw an error.  We set RANDOM_JSON to some
-    # arbitrary value that we know will work.  This isn't going to get
-    # called anyways.
-    # XXX: Is there a better way to do this?
-    RANDOM_JSON = st.none()
+if sys.version_info[:2] == (2, 6):
+    raise RuntimeError("Hypothesis tests are not supported on python2.6. "
+                       "Use python2.7, or python3.3 and greater.")
 
 
+RANDOM_JSON = st.recursive(
+    st.floats() | st.booleans() | st.text() | st.none(),
+    lambda children: st.lists(children) | st.dictionaries(st.text(), children)
+)
+
+
+MAX_EXAMPLES = int(os.environ.get('JP_MAX_EXAMPLES', 1000))
 BASE_SETTINGS = {
     'max_examples': MAX_EXAMPLES,
     'suppress_health_check': [HealthCheck.too_slow],
 }
-
-
-def setup_module():
-    if sys.version_info[:2] == (2, 6):
-        raise SkipTest("Hypothesis test not supported on py26")
 
 
 # For all of these tests they verify these proprties:

--- a/jmespath/lexer.py
+++ b/jmespath/lexer.py
@@ -87,7 +87,15 @@ class Lexer(object):
             elif self._current == '!':
                 yield self._match_or_else('=', 'ne', 'not')
             elif self._current == '=':
-                yield self._match_or_else('=', 'eq', 'unknown')
+                if self._next() == '=':
+                    yield {'type': 'eq', 'value': '==',
+                        'start': self._position - 1, 'end': self._position}
+                    self._next()
+                else:
+                    raise LexerError(
+                        lexer_position=self._position - 1,
+                        lexer_value='=',
+                        message="Unknown token =")
             else:
                 raise LexerError(lexer_position=self._position,
                                  lexer_value=self._current,

--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -39,6 +39,7 @@ class Parser(object):
         'eof': 0,
         'unquoted_identifier': 0,
         'quoted_identifier': 0,
+        'literal': 0,
         'rbracket': 0,
         'rparen': 0,
         'comma': 0,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ py==1.4.12
 tox==1.4.2
 wheel==0.24.0
 coverage==3.7.1
+hypothesis==3.1.0

--- a/tests/compliance/syntax.json
+++ b/tests/compliance/syntax.json
@@ -95,6 +95,14 @@
       {
         "expression": "!",
         "error": "syntax"
+      },
+      {
+        "expression": "@=",
+        "error": "syntax"
+      },
+      {
+        "expression": "@``",
+        "error": "syntax"
       }
     ]
   },

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -1,0 +1,92 @@
+# Test suite using hypothesis to generate test cases.
+# This is in a standalone module so that these tests
+# can a) be run separately and b) allow for customization
+# via env var for longer runs in travis.
+import os
+import sys
+
+from nose.plugins.skip import SkipTest
+from hypothesis import given, settings, assume, HealthCheck
+import hypothesis.strategies as st
+
+from jmespath import lexer
+from jmespath import parser
+from jmespath import exceptions
+
+
+MAX_EXAMPLES = int(os.environ.get('JP_MAX_EXAMPLES', 100))
+if sys.version_info[:2] != (2, 6):
+    RANDOM_JSON = st.recursive(
+        st.floats() | st.booleans() | st.text() | st.none(),
+        lambda children: st.lists(children) | st.dictionaries(st.text(), children)
+    )
+else:
+    # hypothesis doesn't work on py26 and the prevous definition of
+    # RANDOM_JSON would throw an error.  We set RANDOM_JSON to some
+    # arbitrary value that we know will work.  This isn't going to get
+    # called anyways.
+    # XXX: Is there a better way to do this?
+    RANDOM_JSON = st.none()
+
+
+BASE_SETTINGS = {
+    'max_examples': MAX_EXAMPLES,
+    'suppress_health_check': [HealthCheck.too_slow],
+}
+
+
+def setup_module():
+    if sys.version_info[:2] == (2, 6):
+        raise SkipTest("Hypothesis test not supported on py26")
+
+
+# For all of these tests they verify these proprties:
+# either the operation succeeds or it raises a JMESPathError.
+# If any other exception is raised then we error out.
+@settings(**BASE_SETTINGS)
+@given(st.text())
+def test_lexer_api(expr):
+    try:
+        tokens = list(lexer.Lexer().tokenize(expr))
+    except exceptions.JMESPathError as e:
+        return
+    except Exception as e:
+        raise AssertionError("Non JMESPathError raised: %s" % e)
+    assert isinstance(tokens, list)
+
+
+@settings(**BASE_SETTINGS)
+@given(st.text())
+def test_parser_api_from_str(expr):
+    # Same a lexer above with the assumption that we're parsing
+    # a valid sequence of tokens.
+    try:
+        list(lexer.Lexer().tokenize(expr))
+    except exceptions.JMESPathError as e:
+        # We want to try to parse things that tokenize
+        # properly.
+        assume(False)
+    try:
+        ast = parser.Parser().parse(expr)
+    except exceptions.JMESPathError as e:
+        return
+    except Exception as e:
+        raise AssertionError("Non JMESPathError raised: %s" % e)
+    assert isinstance(ast.parsed, dict)
+
+
+@settings(**BASE_SETTINGS)
+@given(expr=st.text(), data=RANDOM_JSON)
+def test_search_api(expr, data):
+    try:
+        ast = parser.Parser().parse(expr)
+    except exceptions.JMESPathError as e:
+        # We want to try to parse things that tokenize
+        # properly.
+        assume(False)
+    try:
+        ast.search(data)
+    except exceptions.JMESPathError as e:
+        return
+    except Exception as e:
+        raise AssertionError("Non JMESPathError raised: %s" % e)


### PR DESCRIPTION
This includes a new suite of tests using [hypothesis](https://hypothesis.readthedocs.org/en/master/).

The one caveat with these tests are that hypothesis does not support python2.6.  To accomodate this, I've added a new `extra/` directory that you can run via `nosetests`.  This does mean that the hypothesis tests aren't run as part of the default suite of tests when your run `nosetests tests/`.

I have added these tests as part of the travis builds with longer iteration counts.

I've also added a fix for two small bugs found.  There were certain expressions that would result in something besides a `JMESPathError` being raised.