### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/proposals/functions.rst
+++ b/docs/proposals/functions.rst
@@ -11,7 +11,7 @@ Abstract
 ========
 
 This document proposes modifying the
-`JMESPath grammar <http://jmespath.readthedocs.org/en/latest/specification.html#grammar>`__
+`JMESPath grammar <https://jmespath.readthedocs.io/en/latest/specification.html#grammar>`__
 to support function expressions.
 
 Motivation

--- a/docs/proposals/nested-expressions.rst
+++ b/docs/proposals/nested-expressions.rst
@@ -10,7 +10,7 @@ Nested Expressions
 Abstract
 ========
 
-This document proposes modifying the `JMESPath grammar <http://jmespath.readthedocs.org/en/latest/specification.html#grammar>`_
+This document proposes modifying the `JMESPath grammar <https://jmespath.readthedocs.io/en/latest/specification.html#grammar>`_
 to support arbitrarily nested expressions within ``multi-select-list`` and
 ``multi-select-hash`` expressions.
 


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
