### PR TITLE
Add back support for order comparisons against strings

### DIFF
--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -1,6 +1,7 @@
 import operator
 
 from jmespath import functions
+from jmespath.compat import string_type
 
 
 def _equals(x, y):
@@ -31,6 +32,14 @@ def _is_special_integer_case(x, y):
         return y is True or y is False
     elif y is 0 or y is 1:
         return x is True or x is False
+
+
+def _is_comparable(x):
+    # The spec doesn't officially support string types yet,
+    # but enough people are relying on this behavior that
+    # it's been added back.  This should eventually become
+    # part of the official spec.
+    return _is_actual_number(x) or isinstance(x, string_type)
 
 
 def _is_actual_number(x):
@@ -142,8 +151,8 @@ class TreeInterpreter(Visitor):
             left = self.visit(node['children'][0], value)
             right = self.visit(node['children'][1], value)
             num_types = (int, float)
-            if not (_is_actual_number(left) and
-                    _is_actual_number(right)):
+            if not (_is_comparable(left) and
+                    _is_comparable(right)):
                 return None
             return comparator_func(left, right)
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -36,3 +36,10 @@ class TestSearchOptions(unittest.TestCase):
             jmespath.search('my_subtract(`10`, `3`)', {}, options=options),
             7
         )
+
+
+class TestPythonSpecificCases(unittest.TestCase):
+    def test_can_compare_strings(self):
+        # This is python specific behavior that's not in the official spec
+        # yet, but this was regression from 0.9.0 so it's been added back.
+        self.assertTrue(jmespath.search('a < b', {'a': '2016', 'b': '2017'}))


### PR DESCRIPTION
The validation added in 0.9.1 to make this compliant with the
spec actually broke a number of people.  I've added this back
and will work on getting the spec updated.

Fixes #124.