### PR TITLE
Handle scientific notation in to_number()

### DIFF
--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -202,12 +202,12 @@ class Functions(with_metaclass(FunctionRegistry, object)):
             return arg
         else:
             try:
-                if '.' in arg:
-                    return float(arg)
-                else:
-                    return int(arg)
+                return int(arg)
             except ValueError:
-                return None
+                try:
+                    return float(arg)
+                except ValueError:
+                    return None
 
     @signature({'types': ['array', 'string']}, {'types': []})
     def _func_contains(self, subject, search):

--- a/tests/compliance/functions.json
+++ b/tests/compliance/functions.json
@@ -496,6 +496,10 @@
       "result": 1.0
     },
     {
+      "expression": "to_number('1e21')",
+      "result": 1e21
+    },
+    {
       "expression": "to_number('1.1')",
       "result": 1.1
     },


### PR DESCRIPTION
Instead just try to parse the number as an int, and
if that fails try float() before returning None.

Fixes #120.