### PR TITLE
Always create a new copy of the function table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ Next Release (TBD)
   (`issue 125 <https://github.com/jmespath/jmespath.py/issues/125>`__)
 * Handle numbers in scientific notation in ``to_number()`` function
   (`issue 120 <https://github.com/jmespath/jmespath.py/issues/120>`__)
+* Fix issue where custom functions would override the function table
+  of the builtin function class
+  (`issue 133 <https://github.com/jmespath/jmespath.py/issues/133>`__)
 
 
 0.9.2

--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -47,7 +47,7 @@ class FunctionRegistry(type):
         super(FunctionRegistry, cls).__init__(name, bases, attrs)
 
     def _populate_function_table(cls):
-        function_table = getattr(cls, 'FUNCTION_TABLE', {})
+        function_table = {}
         # Any method with a @signature decorator that also
         # starts with "_func_" is registered as a function.
         # _func_max_by -> max_by function.

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -38,6 +38,12 @@ class TestSearchOptions(unittest.TestCase):
             jmespath.search('my_subtract(`10`, `3`)', {}, options=options),
             7
         )
+        # Should still be able to use the original functions without
+        # any interference from the CustomFunctions class.
+        self.assertEqual(
+            jmespath.search('length(`[1, 2]`)', {}), 2
+        )
+
 
 
 class TestPythonSpecificCases(unittest.TestCase):


### PR DESCRIPTION
When defining a subclass of ``Functions``, the
``getattr()`` call would retrieve the base classes function
table, mutate the table, and then assign a reference of that
table to the child class.  We want to allow each subclass
to have its own separate copy of the function table so its
created from scratch each time.

I think there's room for optimization here.  We could
copy the parent func table if it exists and iterate through
the ``attrs``, which will only contain the functions defined
in the actual class.

Fixes #133.