### PR TITLE
reverse type of null should be NoneType, not None

### DIFF
--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -28,7 +28,7 @@ REVERSE_TYPES_MAP = {
     'boolean': ('bool',),
     'array': ('list', '_Projection'),
     'object': ('dict', 'OrderedDict',),
-    'null': ('None',),
+    'null': ('NoneType',),
     'string': ('unicode', 'str'),
     'number': ('float', 'int', 'long'),
     'expref': ('_Expression',),

--- a/tests/test_custom_functions.py
+++ b/tests/test_custom_functions.py
@@ -1,0 +1,25 @@
+import unittest
+
+import functions
+import jmespath
+
+
+class CustomFunctions(functions.Functions):
+    @functions.signature({'types': ['string', 'array', 'object', 'null']})
+    def _func_length0(self, s):
+        return 0 if s is None else len(s)
+
+
+class TestCustomFunctions(unittest.TestCase):
+    def setUp(self):
+        self.options = jmespath.Options(custom_functions=CustomFunctions())
+
+    def test_allows_null(self):
+        data = {
+            'a': {
+                'b': [1, 2, 3]
+            }
+        }
+
+        self.assertEqual(jmespath.search('length0(a.b)', data, self.options), 3)
+        self.assertEqual(jmespath.search('length0(a.c)', data, self.options), 0)

--- a/tests/test_custom_functions.py
+++ b/tests/test_custom_functions.py
@@ -1,7 +1,7 @@
 import unittest
 
-import functions
 import jmespath
+from jmespath import functions
 
 
 class CustomFunctions(functions.Functions):
@@ -14,7 +14,7 @@ class TestCustomFunctions(unittest.TestCase):
     def setUp(self):
         self.options = jmespath.Options(custom_functions=CustomFunctions())
 
-    def test_allows_null(self):
+    def test_null_to_nonetype(self):
         data = {
             'a': {
                 'b': [1, 2, 3]


### PR DESCRIPTION
Hi @jamesls, here's the new pull request for #129. I ended up adding an extra file for the test as `test_funcions.py` seemed to be reserved for built-in functions and I couldn't find a more suitable place where to put it. Lemme know if that's okay as it is, or if you require any changes. Thanks.