### PR TITLE
Fix typo in example code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,15 +88,14 @@ of your dict keys.  To do this you can use either of these options:
 .. code:: python
 
     >>> import jmespath
-    >>> jmespath.search('{a: a, b: b},
+    >>> jmespath.search('{a: a, b: b}',
     ...                 mydata,
     ...                 jmespath.Options(dict_cls=collections.OrderedDict))
 
 
     >>> import jmespath
     >>> parsed = jmespath.compile('{a: a, b: b}')
-    >>> parsed.search('{a: a, b: b},
-    ...               mydata,
+    >>> parsed.search(mydata,
     ...               jmespath.Options(dict_cls=collections.OrderedDict))
 
 


### PR DESCRIPTION
The provided example code throws an exception due to an extra arg.

```
>>> import collections
>>> mydata={'a':1, 'b': 2}
>>> 
>>> import jmespath
>>> parsed = jmespath.compile('{a: a, b: b}')
>>> parsed.search('{a: a, b: b}',
...               mydata,
...               jmespath.Options(dict_cls=collections.OrderedDict))
Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
TypeError: search() takes at most 3 arguments (4 given)
>>> 
>>> parsed.search(mydata,
...               jmespath.Options(dict_cls=collections.OrderedDict))
OrderedDict([('a', 1), ('b', 2)])
>>>
```