### PR TITLE
Add empty lists support for min_by() and max_by()

### DIFF
--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -331,14 +331,20 @@ class Functions(with_metaclass(FunctionRegistry, object)):
         keyfunc = self._create_key_func(expref,
                                         ['number', 'string'],
                                         'min_by')
-        return min(array, key=keyfunc)
+        if array:
+            return min(array, key=keyfunc)
+        else:
+            return None
 
     @signature({'types': ['array']}, {'types': ['expref']})
     def _func_max_by(self, array, expref):
         keyfunc = self._create_key_func(expref,
                                         ['number', 'string'],
-                                        'min_by')
-        return max(array, key=keyfunc)
+                                        'max_by')
+        if array:
+            return max(array, key=keyfunc)
+        else:
+            return None
 
     def _create_key_func(self, expref, allowed_types, function_name):
         def keyfunc(x):

--- a/tests/compliance/functions.json
+++ b/tests/compliance/functions.json
@@ -702,6 +702,10 @@
       "result": {"age": 50, "age_str": "50", "bool": false, "name": "d"}
     },
     {
+      "expression": "max_by(`[]`, &age)",
+      "result": null
+    },
+    {
       "expression": "min_by(people, &age)",
       "result": {"age": 10, "age_str": "10", "bool": true, "name": 3}
     },
@@ -720,6 +724,10 @@
     {
       "expression": "min_by(people, &to_number(age_str))",
       "result": {"age": 10, "age_str": "10", "bool": true, "name": 3}
+    },
+    {
+      "expression": "min_by(`[]`, &age)",
+      "result": null
     }
   ]
 }, {


### PR DESCRIPTION
The python implementations of the `min_by` and `max_by` functions raise a `ValueError` if the given array is empty. This is inconsistent with the python implementations of `min` and `max` which return `null` for an empty array. It's also inconsistent with the javascript implementations of the functions, as far as I can tell.

As a bonus, I also discovered that if the key function for `max_by` fails, it prints an error message saying that `min_by` failed.