### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[metadata]
+license_file = LICENSE.txt


### PR DESCRIPTION
The wheel package format supports including the license file. This isdone using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file

Distributing the wheel now complies with the license:

> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.