### PR TITLE
Fix race condition in cache eviction

### DIFF
--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -490,7 +490,7 @@ class Parser(object):
 
     def _free_cache_entries(self):
         for key in random.sample(self._CACHE.keys(), int(self._MAX_SIZE / 2)):
-            del self._CACHE[key]
+            self._CACHE.pop(key, None)
 
     @classmethod
     def purge(cls):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='jmespath',
-    version='0.9.3a1',
+    version='0.9.4a1',
     description='JSON Matching Expressions',
     long_description=io.open('README.rst', encoding='utf-8').read(),
     author='James Saryerwinnie',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='jmespath',
-    version='0.9.3',
+    version='0.9.3a1',
     description='JSON Matching Expressions',
     long_description=io.open('README.rst', encoding='utf-8').read(),
     author='James Saryerwinnie',


### PR DESCRIPTION
Class attributes are more likely to be shared between threads. There is a race if two threads try to evict the same cache entry. Due to the random sampling the race only occurs if the cache is big or there are many threads.

Re the change to `setup.py`, I think it is good practice to always set the version to a pre-release in between actual releases.