### PR TITLE
classifiers needs to be an array

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     scripts=['bin/jp.py'],
     packages=find_packages(exclude=['tests']),
     license='MIT',
-    classifiers=(
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Natural Language :: English',
@@ -33,5 +33,5 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
-    ),
+    ],
 )


### PR DESCRIPTION
This fixes a `python3 bdist_wheel upload` issue:
```
running upload
Traceback (most recent call last):
  File "setup.py", line 35, in <module>
    'Programming Language :: Python :: Implementation :: PyPy',
  File "/usr/local/lib/python3.6/site-packages/setuptools/__init__.py", line 131, in setup
    return distutils.core.setup(**attrs)
  File "/usr/local/lib/python3.6/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/local/lib/python3.6/distutils/dist.py", line 955, in run_commands
    self.run_command(cmd)
  File "/usr/local/lib/python3.6/distutils/dist.py", line 974, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python3.6/distutils/command/upload.py", line 64, in run
    self.upload_file(command, pyversion, filename)
  File "/usr/local/lib/python3.6/distutils/command/upload.py", line 162, in upload_file
    body.write(value)
TypeError: a bytes-like object is required, not 'str'
```