### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ python:
   - "3.5"
   - "3.6"
   - "pypy"
+# Enable 3.7 without globally enabling dist: xenial for other build jobs
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial
 before_install:
   - pip install codecov
 install:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-import os
-import sys
 import io
 
 from setuptools import setup, find_packages
@@ -32,6 +30,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36,pypy
+envlist = py26,py27,py33,py34,py35,py36,py37,pypy
 
 [testenv]
 commands = nosetests


### PR DESCRIPTION
A little workaround is needed on Travis CI, it needs Xenial.