### PR TITLE
treat tuples as lists

### DIFF
--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -202,7 +202,7 @@ class TreeInterpreter(Visitor):
     def visit_index(self, node, value):
         # Even though we can index strings, we don't
         # want to support that.
-        if not isinstance(value, list):
+        if not isinstance(value, (list, tuple)):
             return None
         try:
             return value[node['value']]
@@ -216,7 +216,7 @@ class TreeInterpreter(Visitor):
         return result
 
     def visit_slice(self, node, value):
-        if not isinstance(value, list):
+        if not isinstance(value, (list, tuple)):
             return None
         s = slice(*node['children'])
         return value[s]


### PR DESCRIPTION
I believe now any tuples in input data should be treated as lists.  
use case described in the issue https://github.com/jmespath/jmespath.py/issues/179 now works as expected in the issue  

