### PR TITLE
Support non-ascii characters

### DIFF
--- a/bin/jp.py
+++ b/bin/jp.py
@@ -34,7 +34,7 @@ def main():
         data = json.loads(data)
     try:
         sys.stdout.write(json.dumps(
-            jmespath.search(expression, data), indent=4))
+            jmespath.search(expression, data), indent=4, ensure_ascii=False))
         sys.stdout.write('\n')
     except exceptions.ArityError as e:
         sys.stderr.write("invalid-arity: %s\n" % e)


### PR DESCRIPTION
### description

Currently `./bin/jp.py` is not support non-ascii characters such as "😄"

```
$ echo '{"key":"😄"}' | ./bin/jp.py key
"\ud83d\ude04"
```

This PR fixes it.


### verification 

```
jmespath.py (develop) $ echo '{"key":"😄"}' | ./bin/jp.py key
"\ud83d\ude04"

jmespath.py (develop) $ git switch ensure-ascii
Switched to branch 'ensure-ascii'
jmespath.py (ensure-ascii) $ echo '{"key":"😄"}' | ./bin/jp.py key
"😄"
```