### PR TITLE
Deprecate py26/py33

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+Next Release (TBD)
+==================
+
+* Python 2.6 and 3.3 have reached end-of-life and have been deprecated.
+  They will be dropped in version 0.11.0.
+
+
 0.9.5
 =====
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,21 +2,21 @@ Next Release (TBD)
 ==================
 
 * Python 2.6 and 3.3 have reached end-of-life and have been deprecated.
-  They will be dropped in version 0.11.0.
+  (`issue 175 <https://github.com/jmespath/jmespath.py/issues/175>`__)
 
 
 0.9.5
 =====
 
 * Fix syntax warnings on python 3.8
-  `(`issue 187 <https://github.com/jmespath/jmespath.py/issues/187>`__)
+  (`issue 187 <https://github.com/jmespath/jmespath.py/issues/187>`__)
 
 
 0.9.4
 =====
 
 * Fix ``min_by``/``max_by`` with empty lists
-  `(`issue 151 <https://github.com/jmespath/jmespath.py/pull/151>`__)
+  (`issue 151 <https://github.com/jmespath/jmespath.py/pull/151>`__)
 * Fix reverse type for ``null`` type
   (`issue 145 <https://github.com/jmespath/jmespath.py/pull/145>`__)
 

--- a/jmespath/__init__.py
+++ b/jmespath/__init__.py
@@ -1,7 +1,17 @@
+import warnings
+import sys
 from jmespath import parser
 from jmespath.visitor import Options
 
 __version__ = '0.9.5'
+
+
+if sys.version_info[:2] <= (2, 6) or ((3, 0) <= sys.version_info[:2] <= (3, 3)):
+    python_ver = '.'.join(str(x) for x in sys.version_info[:3])
+
+    warnings.warn('You are using Python {0}, which will no longer be supported in '
+                  'JMESPath 1.0'.format(python_ver),
+                  DeprecationWarning)
 
 
 def compile(expression):

--- a/jmespath/__init__.py
+++ b/jmespath/__init__.py
@@ -9,9 +9,10 @@ __version__ = '0.9.5'
 if sys.version_info[:2] <= (2, 6) or ((3, 0) <= sys.version_info[:2] <= (3, 3)):
     python_ver = '.'.join(str(x) for x in sys.version_info[:3])
 
-    warnings.warn('You are using Python {0}, which will no longer be supported in '
-                  'JMESPath 1.0'.format(python_ver),
-                  DeprecationWarning)
+    warnings.warn(
+        'You are using Python {0}, which will no longer be supported in '
+        'version 0.11.0'.format(python_ver),
+        DeprecationWarning)
 
 
 def compile(expression):

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,10 @@ from setuptools import setup, find_packages
 if sys.version_info[:2] <= (2, 6) or ((3, 0) <= sys.version_info[:2] <= (3, 3)):
     python_ver = '.'.join(str(x) for x in sys.version_info[:3])
 
-    warnings.warn('You are using Python {0}, which will no longer be supported in '
-                  'JMESPath 1.0'.format(python_ver),
-                  PendingDeprecationWarning)
+    warnings.warn(
+        'You are using Python {0}, which will no longer be supported in '
+        'version 0.11.0'.format(python_ver),
+        DeprecationWarning)
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     scripts=['bin/jp.py'],
     packages=find_packages(exclude=['tests']),
     license='MIT',
+    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python
 
 import io
+import sys
+import warnings
 
 from setuptools import setup, find_packages
+
+
+if sys.version_info[:2] <= (2, 6) or ((3, 0) <= sys.version_info[:2] <= (3, 3)):
+    python_ver = '.'.join(str(x) for x in sys.version_info[:3])
+
+    warnings.warn('You are using Python {0}, which will no longer be supported in '
+                  'JMESPath 1.0'.format(python_ver),
+                  DeprecationWarning)
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if sys.version_info[:2] <= (2, 6) or ((3, 0) <= sys.version_info[:2] <= (3, 3)):
 
     warnings.warn('You are using Python {0}, which will no longer be supported in '
                   'JMESPath 1.0'.format(python_ver),
-                  DeprecationWarning)
+                  PendingDeprecationWarning)
 
 
 setup(


### PR DESCRIPTION
This pulls in https://github.com/jmespath/jmespath.py/pull/175 and rebases it against the latest release.

For more context see https://github.com/jmespath/jmespath.py/pull/166