### PR TITLE
Use list for random.sample since using a set has been deprecated since Python 3.9

### DIFF
--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -489,7 +489,7 @@ class Parser(object):
             lex_position, actual_value, actual_type, message)
 
     def _free_cache_entries(self):
-        for key in random.sample(self._CACHE.keys(), int(self._MAX_SIZE / 2)):
+        for key in random.sample(list(self._CACHE.keys()), int(self._MAX_SIZE / 2)):
             self._CACHE.pop(key, None)
 
     @classmethod


### PR DESCRIPTION
Fixes #216 