### PR TITLE
i've added a bump config file to automate the bumping version across …

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,28 @@
+[bumpversion]
+current_version = 0.10.0
+commit = True
+tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*))?
+serialize = 
+	{major}.{minor}.{patch}-{stage}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:stage]
+optional_value = stable
+first_value = stable
+values = 
+	alpha
+	beta
+	stable
+
+[bumpversion:file:jmespath/__init__.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'
+
+[bumpversion:file:docs/conf.py]
+search = release = '{current_version}'
+replace = release = '{new_version}'
+
+[bumpversion:file:setup.py]
+search = version='{current_version}',
+replace = version='{new_version}',


### PR DESCRIPTION
…the library

For the maintainers on how to deploy: if you don't have it yet:
```
$ pip install --user bump2version
$ bump2version patch # or minor or major
```
ex:
version = '0.10.0' --> 'major.minor.patch'
'$ bump2version patch' --> 0.10.1
'$ bump2version minor' --> 0.11.0
etc
once bump it, push the tags as usual:
```
$ git push
$ git push --tags
```
Signed-off-by: Harmouch101 <mahmoudddharmouchhh@gmail.com>