### PR TITLE
Fix pytest warnings, fix tests execution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 nose==1.2.1
 py==1.4.12
+six
 tox==1.4.2
 wheel==0.24.0
 coverage==5.0.3 ; python_version == '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+future
 nose==1.2.1
 py==1.4.12
 six

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -48,7 +48,7 @@ def _walk_files():
 
 
 def load_cases(full_path):
-    all_test_data = json.load(open(full_path), object_pairs_hook=OrderedDict)
+    all_test_data = json.load(open(full_path, encoding='utf-8'), object_pairs_hook=OrderedDict)
     for test_data in all_test_data:
         given = test_data['given']
         for case in test_data['cases']:

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -1,6 +1,9 @@
 import os
 import re
 from pprint import pformat
+
+import six
+
 from tests import OrderedDict
 from tests import json
 from tests import unittest
@@ -10,6 +13,8 @@ from nose.tools import assert_equal
 
 from jmespath.visitor import Options
 
+if six.PY2:
+    from io import open
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 COMPLIANCE_DIR = os.path.join(TEST_DIR, 'compliance')

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,3 +1,4 @@
+from six import assertRaisesRegex
 from tests import unittest
 
 from jmespath import lexer
@@ -152,7 +153,7 @@ class TestRegexLexer(unittest.TestCase):
             tokens = list(self.lexer.tokenize('^foo[0]'))
 
     def test_unknown_character_with_identifier(self):
-        with self.assertRaisesRegexp(LexerError, "Unknown token"):
+        with assertRaisesRegex(self, LexerError, "Unknown token"):
             list(self.lexer.tokenize('foo-bar'))
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -3,6 +3,8 @@ import re
 import random
 import string
 import threading
+
+from six import assertRaisesRegex
 from tests import unittest, OrderedDict
 
 from jmespath import parser
@@ -169,7 +171,7 @@ class TestErrorMessages(unittest.TestCase):
         error_message = re.compile(
             r'Bad jmespath expression: '
             r'Invalid \\uXXXX escape.*\\uAZ12', re.DOTALL)
-        with self.assertRaisesRegexp(exceptions.LexerError, error_message):
+        with assertRaisesRegex(self, exceptions.LexerError, error_message):
             self.parser.parse(r'"\uAZ12"')
 
 


### PR DESCRIPTION
PR related to #222 

- Fix `DeprecationWarning: Please use assertRaisesRegex instead.`: replace `assertRaisesRegexp()` (deprecated since 3.2) to `six.assertRaisesRegex()`
- Fix `PytestCollectionWarning: yield tests were removed in pytest 4.0 - test_compliance will be ignored`: remove yield tests, create test functions' generator in `test_compliance.py`.
- Set open file encoding as utf-8 in `tests\test_compliance.py#load_cases(full_path)`
- Add new modules to requirements.txt for tests: `future`, `six`

After this PR, command `python -Bm pytest -ra` collect and execute all 976 tests (before changes collected only 80 tests).

