### PR TITLE
Use assertRaisesRegex for Python 3.11 compatibility

### DIFF
--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -152,7 +152,7 @@ class TestRegexLexer(unittest.TestCase):
             tokens = list(self.lexer.tokenize('^foo[0]'))
 
     def test_unknown_character_with_identifier(self):
-        with self.assertRaisesRegexp(LexerError, "Unknown token"):
+        with self.assertRaisesRegex(LexerError, "Unknown token"):
             list(self.lexer.tokenize('foo-bar'))
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -169,7 +169,7 @@ class TestErrorMessages(unittest.TestCase):
         error_message = re.compile(
             r'Bad jmespath expression: '
             r'Invalid \\uXXXX escape.*\\uAZ12', re.DOTALL)
-        with self.assertRaisesRegexp(exceptions.LexerError, error_message):
+        with self.assertRaisesRegex(exceptions.LexerError, error_message):
             self.parser.parse(r'"\uAZ12"')
 
 


### PR DESCRIPTION
`assertRaisesRegexp` was deprecated in Python 3.2 and is removed in Python 3.11, to be released in October. Use `assertRaisesRegex` instead.

https://docs.python.org/3.11/whatsnew/3.11.html

The newer `assertRaisesRegex` is in Python 2.7 but I doubt it's in 2.6. However, it's definitely time to drop 2.6.

See also https://github.com/jmespath/jmespath.py/issues/215.