### PR TITLE
Remove stray nose import

### DIFF
--- a/extra/test_hypothesis.py
+++ b/extra/test_hypothesis.py
@@ -6,7 +6,6 @@ import os
 import sys
 import numbers
 
-from nose.plugins.skip import SkipTest
 from hypothesis import given, settings, assume, HealthCheck
 import hypothesis.strategies as st
 


### PR DESCRIPTION
Remove leftover nose import that does not seem to be used and causes
import failure when nose is not installed.