### PR TITLE
Fix Python 3.8 warning for type comparison

### DIFF
--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -29,10 +29,22 @@ def _is_special_integer_case(x, y):
     # Also need to consider that:
     # >>> 0 in [True, False]
     # True
-    if type(x) is int and (x == 0 or x == 1):
-        return y is True or y is False
-    elif type(y) is int and (y == 0 or y == 1):
-        return x is True or x is False
+    if _is_boolean_int(x):
+        return isinstance(y, bool)
+    elif _is_boolean_int(y):
+        return isinstance(x, bool)
+
+def _is_boolean_int(num):
+    """
+    For backwards compatibility, Python considers bool to be an int.
+    This causes issues when doing type comparison with isinstance(x, int).
+    This function ensures the value is an actual int respresenting a boolean.
+    """
+    return (
+        not isinstance(num, bool)
+        and isinstance(num, int)
+        and num in (0, 1)
+    )
 
 
 def _is_comparable(x):


### PR DESCRIPTION
This is an alternative proposal to #228 to address the warning discussed in #210.

The underlying issue that lead to the usage of `is` in this conditional is due to a quirk in Python's type system. For backwards compatibility, Python maintains a type alias such that `isinstance(bool(0), int)` is True. However, this is not a bi-directional alias so `isinstance(0, bool)` is False. We'll use to create `_is_boolean_int` to avoid the current brittle comparison while maintaining the correct value for `_is_special_integer_case`.

@jamesls this is more of a curiousity, but is there a reason jmespath special cases `int` but not `float` in this check? `0.0` and `1.0` would behave the same and simplify some of this logic, but that change appears breaking to current behavior.

```python
>>> 0 == 0.0 == False
True
>>> 1 == 1.0 == True
True
>>> 0.0 in (True, False)
True
>>> 1.0 in (True, False)
True