### PR TITLE
Cleanup lingering code from Python 2.6 and 3.6

### DIFF
--- a/extra/test_hypothesis.py
+++ b/extra/test_hypothesis.py
@@ -3,7 +3,6 @@
 # can a) be run separately and b) allow for customization
 # via env var for longer runs in travis.
 import os
-import sys
 import numbers
 
 from hypothesis import given, settings, assume, HealthCheck
@@ -13,11 +12,6 @@ from jmespath import lexer
 from jmespath import parser
 from jmespath import exceptions
 from jmespath.functions import Functions
-
-
-if sys.version_info[:2] == (2, 6):
-    raise RuntimeError("Hypothesis tests are not supported on python2.6. "
-                       "Use python2.7, or python3.3 and greater.")
 
 
 JSON_NUMBERS = (st.integers() | st.floats(allow_nan=False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 wheel==0.24.0
-pytest==6.2.5 ; python_version >= '3.6'
-pytest<5.0 ; python_version < '3.6'
-pytest-cov==3.0.0 ; python_version >= '3.6'
-pytest-cov<3.0.0 ; python_version < '3.6'
+pytest==6.2.5
+pytest-cov==3.0.0
 hypothesis==3.1.0 ; python_version < '3.8'
 hypothesis==5.5.4 ; python_version == '3.8'
 hypothesis==5.35.4 ; python_version == '3.9'

--- a/requirements26.txt
+++ b/requirements26.txt
@@ -1,4 +1,0 @@
-# For the python2.6 tests, we need ordered dict.
-ordereddict==1.1
-unittest2==0.5.1
-simplejson==3.6.5

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,18 +1,9 @@
 import sys
 from jmespath import ast
 
-
-# The unittest module got a significant overhaul
-# in 2.7, so if we're in 2.6 we can use the backported
-# version unittest2.
-if sys.version_info[:2] == (2, 6):
-    import unittest2 as unittest
-    import simplejson as json
-    from ordereddict import OrderedDict
-else:
-    import unittest
-    import json
-    from collections import OrderedDict
+import unittest
+import json
+from collections import OrderedDict
 
 
 # Helper method used to create an s-expression


### PR DESCRIPTION
Quick PR to remove remaining legacy code for Python 2.6 and a block of 3.6-specific dependencies.