### PR TITLE
Update changelog for 1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+1.0.0
+=====
+
+* Drop support for Python versions less than 3.7 (including Python 2).
+  (`issue 268 <https://github.com/jmespath/jmespath.py/issues/268>`__)
+
+
 0.10.0
 ======
 


### PR DESCRIPTION
The majority of these changes for 1.0.0 were all internal dev
changes (switching to pytest, migrating to github actions, etc).
The only user visible change was dropping support for EOL'd
Python versions.

NOTE: I'll switch the changelog management over to jmeslog so
this can be part of the automated release process going forward.

Fixes #277 