### PR TITLE
Fix boolean correctness for floats

### DIFF
--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -6,13 +6,13 @@ from numbers import Number
 
 
 def _equals(x, y):
-    if _is_special_integer_case(x, y):
+    if _is_special_number_case(x, y):
         return False
     else:
         return x == y
 
 
-def _is_special_integer_case(x, y):
+def _is_special_number_case(x, y):
     # We need to special case comparing 0 or 1 to
     # True/False.  While normally comparing any
     # integer other than 0/1 to True/False will always
@@ -29,22 +29,10 @@ def _is_special_integer_case(x, y):
     # Also need to consider that:
     # >>> 0 in [True, False]
     # True
-    if _is_boolean_int(x):
+    if _is_actual_number(x) and x in (0, 1):
         return isinstance(y, bool)
-    elif _is_boolean_int(y):
+    elif _is_actual_number(y) and y in (0, 1):
         return isinstance(x, bool)
-
-def _is_boolean_int(num):
-    """
-    For backwards compatibility, Python considers bool to be an int.
-    This causes issues when doing type comparison with isinstance(x, int).
-    This function ensures the value is an actual int respresenting a boolean.
-    """
-    return (
-        not isinstance(num, bool)
-        and isinstance(num, int)
-        and num in (0, 1)
-    )
 
 
 def _is_comparable(x):
@@ -63,7 +51,7 @@ def _is_actual_number(x):
     # True
     # >>> isinstance(True, int)
     # True
-    if x is True or x is False:
+    if isinstance(x, bool):
         return False
     return isinstance(x, Number)
 
@@ -269,7 +257,7 @@ class TreeInterpreter(Visitor):
 
     def visit_not_expression(self, node, value):
         original_result = self.visit(node['children'][0], value)
-        if type(original_result) is int and original_result == 0:
+        if _is_actual_number(original_result) and original_result == 0:
             # Special case for 0, !0 should be false, not true.
             # 0 is not a special cased integer in jmespath.
             return False

--- a/tests/compliance/boolean.json
+++ b/tests/compliance/boolean.json
@@ -76,7 +76,8 @@
       "False": false,
       "Number": 5,
       "EmptyList": [],
-      "Zero": 0
+      "Zero": 0,
+      "ZeroFloat": 0.0
     },
     "cases": [
       {
@@ -198,6 +199,14 @@
       {
         "expression": "!!Zero",
         "result": true
+      },
+      {
+        "expression": "Zero || Number",
+        "result": 0
+      },
+      {
+        "expression": "ZeroFloat || Number",
+        "result": 0.0
       }
     ]
   },

--- a/tests/compliance/filters.json
+++ b/tests/compliance/filters.json
@@ -266,6 +266,88 @@
     ]
   },
   {
+    "given": {"foo": [
+      {"key": true},
+      {"key": false},
+      {"key": 0},
+      {"key": 0.0},
+      {"key": 1},
+      {"key": 1.0},
+      {"key": [0]},
+      {"key": null},
+      {"key": [1]},
+      {"key": []},
+      {"key": {}},
+      {"key": {"a":2}}
+    ]},
+    "cases": [
+      {
+        "expression": "foo[?key == `true`]",
+        "result": [{"key": true}]
+      },
+      {
+        "expression": "foo[?key == `false`]",
+        "result": [{"key": false}]
+      },
+      {
+        "expression": "foo[?key]",
+        "result": [
+          {"key": true},
+          {"key": 0},
+          {"key": 0.0},
+          {"key": 1},
+          {"key": 1.0},
+          {"key": [0]},
+          {"key": [1]},
+          {"key": {"a": 2}}
+        ]
+      },
+      {
+        "expression": "foo[? !key]",
+        "result": [
+          {"key": false},
+          {"key": null},
+          {"key": []},
+          {"key": {}}
+        ]
+      },
+      {
+        "expression": "foo[? !!key]",
+        "result": [
+          {"key": true},
+          {"key": 0},
+          {"key": 0.0},
+          {"key": 1},
+          {"key": 1.0},
+          {"key": [0]},
+          {"key": [1]},
+          {"key": {"a": 2}}
+        ]
+      },
+      {
+        "expression": "foo[? `true`]",
+        "result": [
+          {"key": true},
+          {"key": false},
+          {"key": 0},
+          {"key": 0.0},
+          {"key": 1},
+          {"key": 1.0},
+          {"key": [0]},
+          {"key": null},
+          {"key": [1]},
+          {"key": []},
+          {"key": {}},
+          {"key": {"a":2}}
+        ]
+      },
+      {
+        "expression": "foo[? `false`]",
+        "result": []
+      }
+    ]
+  },
+  {
     "given": {"reservations": [
       {"instances": [
         {"foo": 1, "bar": 2}, {"foo": 1, "bar": 3},


### PR DESCRIPTION
From [pr 278](https://github.com/jmespath/jmespath.py/pull/278#issuecomment-1076796069), floats did not properly adhere to the boolean behavior specified in the [jmespath spec](https://jmespath.org/specification.html#or-expressions):

>  A false value corresponds to any of the following conditions:
>
>    Empty list: []
>    Empty object: {}
>    Empty string: ""
>    False boolean: false
>    Null value: null
>
> A true value corresponds to any value that is not false.

So specifically, a value of `0.0` should NOT evaluate to a false value.  However, in python, this *is* the case:

```
>>> "true value" if 0.0 else "false value"
'false value'
```

So we need to explicitly override python's behavior here.