### PR TITLE
Add testing for Python 3.11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],


### PR DESCRIPTION
This PR is a follow up from boto/botocore#2693. We're working on adding Python 3.11 support and the current release of jmespath isn't compatible. The fix was already merged in #217 though, we just need a new release.

In this PR, we'll add 3.11 to the CI to ensure new regressions aren't introduced during the bug fix phase of the release. The identifier is "3.11-dev" which will roll over to the final release of 3.11. This will eventually need to be moved to just "3.11" at some point after GA.

This also adds the 3.11 trove classifier to let downstream consumers know this package is currently testing on this build and enable easier tracking on community tools like [pyreadiness](https://pyreadiness.org/3.11/).