### PR TITLE
Remove uneeded cast to `float` in `avg` function

### DIFF
--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -168,7 +168,7 @@ class Functions(metaclass=FunctionRegistry):
     @signature({'types': ['array-number']})
     def _func_avg(self, arg):
         if arg:
-            return sum(arg) / float(len(arg))
+            return sum(arg) / len(arg)
         else:
             return None
 


### PR DESCRIPTION
Python3 implemented [PEP-238](https://peps.python.org/pep-0238/) which changes the way the division operator is applyied. In Python3 is not needed a float casting to get the result of a "true division" rather than the previous "floor division". As I can see, jmespath.py [does not support Python2](https://github.com/jmespath/jmespath.py/blob/bbe7300c60056f52413603cf3e2bcd0b6afeda3d/setup.py#L19) so this cast can be removed.