### PR TITLE
JEP-19 Evaluation of Pipe Expressions

### DIFF
--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -129,6 +129,8 @@ class TreeInterpreter(Visitor):
         result = value
         for node in node['children']:
             result = self.visit(node, result)
+            if (result is None):
+                return None
         return result
 
     def visit_field(self, node, value):
@@ -228,16 +230,12 @@ class TreeInterpreter(Visitor):
         return node['value']
 
     def visit_multi_select_dict(self, node, value):
-        if value is None:
-            return None
         collected = self._dict_cls()
         for child in node['children']:
             collected[child['value']] = self.visit(child, value)
         return collected
 
     def visit_multi_select_list(self, node, value):
-        if value is None:
-            return None
         collected = []
         for child in node['children']:
             collected.append(self.visit(child, value))

--- a/tests/compliance/pipe.json
+++ b/tests/compliance/pipe.json
@@ -126,6 +126,10 @@
     {
       "expression": "foo[*].bar[*] | [0][0]",
       "result": {"baz": "one"}
+    },
+    {
+      "expression": "`null`|[@]",
+      "result": [ null ]
     }
   ]
 }]


### PR DESCRIPTION
## Sub Expression

The specification for [`sub-expression`](https://jmespath.org/specification.html#subexpressions) outlines how it should behave in pseudocode:

```
left-evaluation = search(left-expression, original-json-document)
result = search(right-expression, left-evaluation)
```

However, this is incorrect, as many compliance tests expect the result to be `null` when the left-hand-side evaluates to  `null`.
So, the real pseudocode shoud in fact be:

```
left-evaluation = search(left-expression, original-json-document)
if left-evaluation is `null` then result = `null`
else result = search(right-expression, left-evaluation)
```

## Pipe Expression

**However**, it seems intuitive for `pipe-expression` to behave as is specified by the pseudocode above.

```
left-evaluation = search(left-expression, original-json-document)
result = search(right-expression, left-evaluation)
```

Which means that the evaluation should still happens if the left-hand-side is `null`.

## Summary

This PR introduces a new compliance test that outlines the following expression: `` search ( `null` | [@], {} ) -> [ null ] `` in the hope to standardize the exact behaviour of pipe expressions.

