### PR TITLE
Fixed non-standard reverse-solidus escape sequence in raw-string literals

### DIFF
--- a/jmespath/lexer.py
+++ b/jmespath/lexer.py
@@ -191,7 +191,10 @@ class Lexer(object):
 
     def _consume_raw_string_literal(self):
         start = self._position
-        lexeme = self._consume_until("'").replace("\\'", "'")
+        lexeme = self._consume_until("'") \
+            .replace("\\'", "'")  \
+            .replace("\\\\", "\\")
+
         token_len = self._position - start
         return {'type': 'literal', 'value': lexeme,
                 'start': start, 'end': token_len}

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -108,6 +108,30 @@ class TestRegexLexer(unittest.TestCase):
         tokens = list(self.lexer.tokenize('``'))
         self.assert_tokens(tokens, [{'type': 'literal', 'value': ''}])
 
+    def test_raw_string_literal(self):
+        tokens = list(self.lexer.tokenize("'foo'"))
+        self.assert_tokens(tokens, [
+            {'type': 'literal', 'value': 'foo'}
+        ])
+
+    def test_raw_string_literal_preserve_escape(self):
+        tokens = list(self.lexer.tokenize("'foo\\z'"))
+        self.assert_tokens(tokens, [
+            {'type': 'literal', 'value': 'foo\\z'}
+        ])
+
+    def test_raw_string_literal_escaped_apostrophe(self):
+        tokens = list(self.lexer.tokenize("'foo\\\'bar'"))
+        self.assert_tokens(tokens, [
+            {'type': 'literal', 'value': 'foo\'bar'}
+        ])
+
+    def test_raw_string_literal_escaped_reverse_solidus(self):
+        tokens = list(self.lexer.tokenize("'foo\\\\bar'"))
+        self.assert_tokens(tokens, [
+            {'type': 'literal', 'value': 'foo\\bar'}
+        ])
+
     def test_position_information(self):
         tokens = list(self.lexer.tokenize('foo'))
         self.assertEqual(


### PR DESCRIPTION
`raw-string` now supports `` \\ `` as a valid escape sequence for a single `\` character.

This needs to be synchronized with [jmespath.test#17](https://github.com/jmespath-community/jmespath.test/pull/17) that fixes [jmespath.test#15](https://github.com/jmespath-community/jmespath.test/issues/15)


