### PR TITLE
Add support for 'arraylike' objects as JSON arrays

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+Unreleased
+==========
+
+* Added support for Arraylike python objects as json arrays.
+
 1.0.1
 =====
 

--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -1,5 +1,6 @@
 import math
 import json
+from typing import Sequence
 
 from jmespath import exceptions
 from jmespath.compat import string_type as STRING_TYPE
@@ -33,6 +34,14 @@ REVERSE_TYPES_MAP = {
     'number': ('float', 'int', 'long'),
     'expref': ('_Expression',),
 }
+
+
+def is_array(arg):
+    return hasattr(arg, "__array__")
+
+
+def is_arraylike(arg):
+    return (isinstance(arg, Sequence) and not isinstance(arg, (str, bytes))) or is_array(arg)
 
 
 def signature(*arguments):
@@ -180,7 +189,7 @@ class Functions(metaclass=FunctionRegistry):
 
     @signature({'types': []})
     def _func_to_array(self, arg):
-        if isinstance(arg, list):
+        if is_arraylike(arg):
             return arg
         else:
             return [arg]
@@ -297,7 +306,7 @@ class Functions(metaclass=FunctionRegistry):
             return "string"
         elif isinstance(arg, bool):
             return "boolean"
-        elif isinstance(arg, list):
+        elif is_arraylike(arg):
             return "array"
         elif isinstance(arg, dict):
             return "object"

--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -37,7 +37,7 @@ REVERSE_TYPES_MAP = {
 
 
 def is_array(arg):
-    return hasattr(arg, "__array__")
+    return hasattr(arg, "__array__") and arg.shape != ()
 
 
 def is_arraylike(arg):

--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -1,6 +1,6 @@
 import math
 import json
-from typing import Sequence
+from collections.abc import Sequence
 
 from jmespath import exceptions
 from jmespath.compat import string_type as STRING_TYPE

--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -37,7 +37,9 @@ REVERSE_TYPES_MAP = {
 
 
 def is_array(arg):
-    return hasattr(arg, "__array__") and arg.shape != ()
+    # Is trivially convertible to a non-scalar ndarray via array method. see:
+    # https://numpy.org/doc/stable/user/basics.interoperability.html#the-array-method
+    return hasattr(arg, "__array__") and arg.__array__().shape != ()
 
 
 def is_arraylike(arg):

--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -1,13 +1,20 @@
 import operator
 
 from jmespath import functions
+from jmespath.functions import is_array, is_arraylike
 from jmespath.compat import string_type
 from numbers import Number
+
+
+def _arraylike_all(arg):
+    return arg.__array__().all() if is_array(arg) else arg
 
 
 def _equals(x, y):
     if _is_special_number_case(x, y):
         return False
+    elif is_array(x) or is_array(y):
+        return _arraylike_all(x == y)
     else:
         return x == y
 
@@ -172,7 +179,7 @@ class TreeInterpreter(Visitor):
 
     def visit_filter_projection(self, node, value):
         base = self.visit(node['children'][0], value)
-        if not isinstance(base, list):
+        if not is_arraylike(base):
             return None
         comparator_node = node['children'][2]
         collected = []
@@ -185,12 +192,12 @@ class TreeInterpreter(Visitor):
 
     def visit_flatten(self, node, value):
         base = self.visit(node['children'][0], value)
-        if not isinstance(base, list):
-            # Can't flatten the object if it's not a list.
+        if not is_arraylike(base):
+            # Can't flatten the object if it's not arraylike.
             return None
         merged_list = []
         for element in base:
-            if isinstance(element, list):
+            if is_arraylike(element):
                 merged_list.extend(element)
             else:
                 merged_list.append(element)
@@ -202,7 +209,7 @@ class TreeInterpreter(Visitor):
     def visit_index(self, node, value):
         # Even though we can index strings, we don't
         # want to support that.
-        if not isinstance(value, list):
+        if not is_arraylike(value):
             return None
         try:
             return value[node['value']]
@@ -216,7 +223,7 @@ class TreeInterpreter(Visitor):
         return result
 
     def visit_slice(self, node, value):
-        if not isinstance(value, list):
+        if not is_arraylike(value):
             return None
         s = slice(*node['children'])
         return value[s]
@@ -271,7 +278,7 @@ class TreeInterpreter(Visitor):
 
     def visit_projection(self, node, value):
         base = self.visit(node['children'][0], value)
-        if not isinstance(base, list):
+        if not is_arraylike(base):
             return None
         collected = []
         for element in base:

--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -10,13 +10,17 @@ def _arraylike_all(arg):
     return arg.__array__().all() if is_array(arg) else arg
 
 
+def _arraylike_to_list(arg):
+    return [_arraylike_to_list(i) for i in arg] if is_arraylike(arg) else arg
+
+
 def _equals(x, y):
     if _is_special_number_case(x, y):
         return False
     elif is_array(x) or is_array(y):
         return _arraylike_all(x == y)
     else:
-        return x == y
+        return _arraylike_to_list(x) == _arraylike_to_list(y)
 
 
 def _is_special_number_case(x, y):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ hypothesis==3.1.0 ; python_version < '3.8'
 hypothesis==5.5.4 ; python_version == '3.8'
 hypothesis==5.35.4 ; python_version == '3.9'
 numpy>=1.15.0
+astropy>=3.1
 xarray>=0.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pytest-cov==3.0.0
 hypothesis==3.1.0 ; python_version < '3.8'
 hypothesis==5.5.4 ; python_version == '3.8'
 hypothesis==5.35.4 ; python_version == '3.9'
-numpy>=1.15.0
 astropy>=3.1
+dask>=2.0.0
+numpy>=1.15.0
 xarray>=0.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 wheel==0.38.1
+parameterized==0.9.0
 pytest==6.2.5
 pytest-cov==3.0.0
 hypothesis==3.1.0 ; python_version < '3.8'
 hypothesis==5.5.4 ; python_version == '3.8'
 hypothesis==5.35.4 ; python_version == '3.9'
+numpy>=1.15.0
+xarray>=0.18.0

--- a/tests/test_arraylike.py
+++ b/tests/test_arraylike.py
@@ -1,0 +1,97 @@
+import numpy as np
+import xarray as xr
+from parameterized import parameterized, parameterized_class
+
+import jmespath
+import jmespath.functions
+from tests import unittest
+
+
+@parameterized_class(("name", "data"), [
+    ("list", {
+        "a": {
+            "data": [[1,2,3],[4,5,6],[7,8,9]]
+        },
+        "b": {
+            "data": [[1,2,3],[4,5,6],[7,8,9]]
+        },
+        "c": {
+            "data": [[2,2,3],[4,5,6],[7,8,9]]
+        }
+    }),
+    ("numpy", {
+        "a": {
+            "data": np.array([[1,2,3],[4,5,6],[7,8,9]])
+        },
+        "b": {
+            "data": np.array([[1,2,3],[4,5,6],[7,8,9]], dtype='int16')
+        },
+        "c": {
+            "data": np.array([[2,2,3],[4,5,6],[7,8,9]])
+        }
+    }),
+    ("xarray", {
+        "a": {
+            "data": xr.DataArray([[1,2,3],[4,5,6],[7,8,9]])
+        },
+        "b": {
+            "data": xr.DataArray([[1,2,3],[4,5,6],[7,8,9]])
+        },
+        "c": {
+            "data": xr.DataArray([[2,2,3],[4,5,6],[7,8,9]])
+        }
+    })
+])
+class TestArrayNumeric(unittest.TestCase):
+    @parameterized.expand([
+        ["self", "@", lambda data: data],
+        ["get", "a.data", lambda data: data["a"]["data"]],
+        ["slice_horizontal", "a.data[1][:]", lambda data: np.array(data["a"]["data"])[1,:]],
+        ["slice_horizontal2", "a.data[:3:2][:]", lambda data: np.array(data["a"]["data"])[:3:2,:]],
+        ["slice_vertical", "a.data[:][1]", lambda data: np.array(data["a"]["data"])[:,1]],
+        ["slice_vertical2", "a.data[:][:3:2]", lambda data: np.array(data["a"]["data"])[:,:3:2]],
+        ["flatten", "a.data[]", lambda data: np.array(data["a"]["data"]).flatten()],
+        ["compare_self", "a.data == a.data", lambda _: True],
+        ["compare_same", "a.data == b.data", lambda _: True],
+        ["compare_other", "a.data == c.data", lambda _: False],
+        ["compare_literal_scalar", "a.data[0][0] == `1`", lambda _: True],
+        ["compare_literal_slice", "a.data[1][:] == `[4, 5, 6]`", lambda _: True],
+        ["compare_literal", "a.data == `[[1,2,3],[4,5,6],[7,8,9]]`", lambda _: True],
+        ["compare_flattened", "a.data[] == `[1,2,3,4,5,6,7,8,9]`", lambda _: True],
+    ])
+    def test_search(self, test_name, query, expected):
+        result = jmespath.search(query, self.data)
+        np.testing.assert_array_equal(result, expected(self.data), test_name)
+
+
+@parameterized_class(("name", "data"), [
+    ("numpy", {
+        "a": { 
+            "data": np.array([["test", "messages"],["in", "numpy"]])
+        },
+        "b": { 
+            "data": np.array([["test", "messages"],["in", "numpy"]])
+        },
+        "c": { 
+            "data": np.array([["test", "messages"],["other", "numpy"]])
+        }
+    })
+])
+class TestArrayStr(unittest.TestCase):
+    @parameterized.expand([
+        ["self", "@", lambda data: data],
+        ["get", "a.data", lambda data: data["a"]["data"]],
+        ["slice_horizontal", "a.data[1][:]", lambda data: data["a"]["data"][1,:]],
+        ["slice_vertical", "a.data[:][1]", lambda data: data["a"]["data"][:,1]],
+        ["flatten", "a.data[]", lambda data: data["a"]["data"].flatten()],
+        ["compare_self", "a.data == a.data", lambda _: True],
+        ["compare_same", "a.data == b.data", lambda _: True],
+        ["compare_other", "a.data == c.data", lambda _: False],
+        ["compare_literal_scalar", "a.data[0][0] == 'test'", lambda _: True],
+        ["compare_literal_slice", "a.data[1][:] == ['in', 'numpy']", lambda _: True],
+        ["compare_literal", "a.data == [['test', 'messages'],['in', 'numpy']]", lambda _: True],
+        ["compare_flattened", "a.data[] == ['test', 'messages', 'in', 'numpy']", lambda _: True],
+    ])
+    def test_search(self, name, query, expected):
+        result = jmespath.search(query, self.data)
+        np.testing.assert_array_equal(result, expected(self.data), name)

--- a/tests/test_arraylike.py
+++ b/tests/test_arraylike.py
@@ -1,3 +1,4 @@
+import astropy.units as u
 import numpy as np
 import xarray as xr
 from parameterized import parameterized, parameterized_class
@@ -50,6 +51,17 @@ from tests import unittest
         },
         "other": {
             "data": xr.DataArray([[2,2,3],[4,5,6],[7,8,9]])
+        }
+    }),
+    ("astropy", {
+        "value": {
+            "data": u.Quantity([[1,2,3],[4,5,6],[7,8,9]])
+        },
+        "same": {
+            "data": (u.Quantity([1,2,3]),u.Quantity([4,5,6]),u.Quantity([7,8,9]))
+        },
+        "other": {
+            "data": u.Quantity([[2,2,3],[4,5,6],[7,8,9]])
         }
     })
 ])

--- a/tests/test_arraylike.py
+++ b/tests/test_arraylike.py
@@ -9,35 +9,46 @@ from tests import unittest
 
 @parameterized_class(("name", "data"), [
     ("list", {
-        "a": {
+        "value": {
             "data": [[1,2,3],[4,5,6],[7,8,9]]
         },
-        "b": {
+        "same": {
             "data": [[1,2,3],[4,5,6],[7,8,9]]
         },
-        "c": {
+        "other": {
+            "data": [[2,2,3],[4,5,6],[7,8,9]]
+        }
+    }),
+    ("tuple", {
+        "value": {
+            "data": ((1,2,3),(4,5,6),(7,8,9))
+        },
+        "same": {
+            "data": ([1,2,3],[4,5,6],[7,8,9])
+        },
+        "other": {
             "data": [[2,2,3],[4,5,6],[7,8,9]]
         }
     }),
     ("numpy", {
-        "a": {
+        "value": {
             "data": np.array([[1,2,3],[4,5,6],[7,8,9]])
         },
-        "b": {
-            "data": np.array([[1,2,3],[4,5,6],[7,8,9]], dtype='int16')
+        "same": {
+            "data": (np.array([1,2,3]),np.array([4,5,6]),np.array([7,8,9]))
         },
-        "c": {
+        "other": {
             "data": np.array([[2,2,3],[4,5,6],[7,8,9]])
         }
     }),
     ("xarray", {
-        "a": {
+        "value": {
             "data": xr.DataArray([[1,2,3],[4,5,6],[7,8,9]])
         },
-        "b": {
-            "data": xr.DataArray([[1,2,3],[4,5,6],[7,8,9]])
+        "same": {
+            "data": (xr.DataArray([1,2,3]),xr.DataArray([4,5,6]),xr.DataArray([7,8,9]))
         },
-        "c": {
+        "other": {
             "data": xr.DataArray([[2,2,3],[4,5,6],[7,8,9]])
         }
     })
@@ -45,19 +56,19 @@ from tests import unittest
 class TestArrayNumeric(unittest.TestCase):
     @parameterized.expand([
         ["self", "@", lambda data: data],
-        ["get", "a.data", lambda data: data["a"]["data"]],
-        ["slice_horizontal", "a.data[1][:]", lambda data: np.array(data["a"]["data"])[1,:]],
-        ["slice_horizontal2", "a.data[:3:2][:]", lambda data: np.array(data["a"]["data"])[:3:2,:]],
-        ["slice_vertical", "a.data[:][1]", lambda data: np.array(data["a"]["data"])[:,1]],
-        ["slice_vertical2", "a.data[:][:3:2]", lambda data: np.array(data["a"]["data"])[:,:3:2]],
-        ["flatten", "a.data[]", lambda data: np.array(data["a"]["data"]).flatten()],
-        ["compare_self", "a.data == a.data", lambda _: True],
-        ["compare_same", "a.data == b.data", lambda _: True],
-        ["compare_other", "a.data == c.data", lambda _: False],
-        ["compare_literal_scalar", "a.data[0][0] == `1`", lambda _: True],
-        ["compare_literal_slice", "a.data[1][:] == `[4, 5, 6]`", lambda _: True],
-        ["compare_literal", "a.data == `[[1,2,3],[4,5,6],[7,8,9]]`", lambda _: True],
-        ["compare_flattened", "a.data[] == `[1,2,3,4,5,6,7,8,9]`", lambda _: True],
+        ["get", "value.data", lambda data: data["value"]["data"]],
+        ["slice_horizontal", "value.data[1][:]", lambda data: np.array(data["value"]["data"])[1,:]],
+        ["slice_horizontal2", "value.data[:3:2][:]", lambda data: np.array(data["value"]["data"])[:3:2,:]],
+        ["slice_vertical", "value.data[:][1]", lambda data: np.array(data["value"]["data"])[:,1]],
+        ["slice_vertical2", "value.data[:][:3:2]", lambda data: np.array(data["value"]["data"])[:,:3:2]],
+        ["flatten", "value.data[]", lambda data: np.array(data["value"]["data"]).flatten()],
+        ["compare_self", "value.data == value.data", lambda _: True],
+        ["compare_same", "value.data == same.data", lambda _: True],
+        ["compare_other", "value.data == other.data", lambda _: False],
+        ["compare_literal_scalar", "value.data[0][0] == `1`", lambda _: True],
+        ["compare_literal_slice", "value.data[1][:] == `[4, 5, 6]`", lambda _: True],
+        ["compare_literal", "value.data == `[[1,2,3],[4,5,6],[7,8,9]]`", lambda _: True],
+        ["compare_flattened", "value.data[] == `[1,2,3,4,5,6,7,8,9]`", lambda _: True],
     ])
     def test_search(self, test_name, query, expected):
         result = jmespath.search(query, self.data)
@@ -66,13 +77,13 @@ class TestArrayNumeric(unittest.TestCase):
 
 @parameterized_class(("name", "data"), [
     ("numpy", {
-        "a": { 
+        "value": { 
             "data": np.array([["test", "messages"],["in", "numpy"]])
         },
-        "b": { 
+        "same": { 
             "data": np.array([["test", "messages"],["in", "numpy"]])
         },
-        "c": { 
+        "other": { 
             "data": np.array([["test", "messages"],["other", "numpy"]])
         }
     })
@@ -80,17 +91,17 @@ class TestArrayNumeric(unittest.TestCase):
 class TestArrayStr(unittest.TestCase):
     @parameterized.expand([
         ["self", "@", lambda data: data],
-        ["get", "a.data", lambda data: data["a"]["data"]],
-        ["slice_horizontal", "a.data[1][:]", lambda data: data["a"]["data"][1,:]],
-        ["slice_vertical", "a.data[:][1]", lambda data: data["a"]["data"][:,1]],
-        ["flatten", "a.data[]", lambda data: data["a"]["data"].flatten()],
-        ["compare_self", "a.data == a.data", lambda _: True],
-        ["compare_same", "a.data == b.data", lambda _: True],
-        ["compare_other", "a.data == c.data", lambda _: False],
-        ["compare_literal_scalar", "a.data[0][0] == 'test'", lambda _: True],
-        ["compare_literal_slice", "a.data[1][:] == ['in', 'numpy']", lambda _: True],
-        ["compare_literal", "a.data == [['test', 'messages'],['in', 'numpy']]", lambda _: True],
-        ["compare_flattened", "a.data[] == ['test', 'messages', 'in', 'numpy']", lambda _: True],
+        ["get", "value.data", lambda data: data["value"]["data"]],
+        ["slice_horizontal", "value.data[1][:]", lambda data: data["value"]["data"][1,:]],
+        ["slice_vertical", "value.data[:][1]", lambda data: data["value"]["data"][:,1]],
+        ["flatten", "value.data[]", lambda data: data["value"]["data"].flatten()],
+        ["compare_self", "value.data == value.data", lambda _: True],
+        ["compare_same", "value.data == same.data", lambda _: True],
+        ["compare_other", "value.data == other.data", lambda _: False],
+        ["compare_literal_scalar", "value.data[0][0] == 'test'", lambda _: True],
+        ["compare_literal_slice", "value.data[1][:] == ['in', 'numpy']", lambda _: True],
+        ["compare_literal", "value.data == [['test', 'messages'],['in', 'numpy']]", lambda _: True],
+        ["compare_flattened", "value.data[] == ['test', 'messages', 'in', 'numpy']", lambda _: True],
     ])
     def test_search(self, name, query, expected):
         result = jmespath.search(query, self.data)

--- a/tests/test_arraylike.py
+++ b/tests/test_arraylike.py
@@ -1,4 +1,5 @@
 import astropy.units as u
+import dask.array as da
 import numpy as np
 import xarray as xr
 from parameterized import parameterized, parameterized_class
@@ -42,6 +43,17 @@ from tests import unittest
             "data": np.array([[2,2,3],[4,5,6],[7,8,9]])
         }
     }),
+    ("dask", {
+        "value": {
+            "data": da.from_array([[1,2,3],[4,5,6],[7,8,9]])
+        },
+        "same": {
+            "data": (da.from_array([1,2,3]),da.from_array([4,5,6]),da.from_array([7,8,9]))
+        },
+        "other": {
+            "data": da.from_array([[2,2,3],[4,5,6],[7,8,9]])
+        }
+    }),
     ("xarray", {
         "value": {
             "data": xr.DataArray([[1,2,3],[4,5,6],[7,8,9]])
@@ -63,7 +75,7 @@ from tests import unittest
         "other": {
             "data": u.Quantity([[2,2,3],[4,5,6],[7,8,9]])
         }
-    })
+    }),
 ])
 class TestArrayNumeric(unittest.TestCase):
     @parameterized.expand([


### PR DESCRIPTION
JMESPath.py is limited in that only the `dict` and `list` derived containers returned by the built-in `json` library are supported in the object hierarchy due to the use of `isinstance`. A very notable arraylike instance that does not derive directly from these containers is a `numpy.ndarray` which can be deserialized using the JSON-like `msgpack` library with `msgpack_numpy`.

This changeset aims to add support for arraylike (`list`, `tuple` and `numpy.ndarray`) containers in place of parsed JSON arrays and without adding any dependency on the `numpy` library. This is done using the documented [numpy array interface protocol](https://numpy.org/devdocs/user/basics.interoperability.html#the-array-interface-protocol) of which many more arraylike libraries adhere to such as `xarray`, `dask`, `astropy` and `cupy`.

(`pandas.Series` is also arraylike but limited to 1D as multidimensional Series isn't an intended use case and has slicing issues)