### PR TITLE
Fix concurrency issues with cache

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2
@@ -25,4 +25,4 @@ jobs:
         pip install dist/*.whl
     - name: Test with pytest
       run: |
-        cd tests/ && py.test --cov jmespath --cov-report term-missing
+        cd tests/ && python -m pytest --cov jmespath --cov-report term-missing

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+Next Release (TBD)
+==================
+
+* Fix concurrency issue with cache
+  (`pr #335 <https://github.com/jmespath/jmespath.py/pull/335>`__)
+
+
 1.0.1
 =====
 

--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -25,8 +25,6 @@ A few notes on the implementation.
   consuming from the token iterator one token at a time.
 
 """
-import random
-
 from jmespath import lexer
 from jmespath.compat import with_repr_method
 from jmespath import ast
@@ -82,13 +80,26 @@ class Parser(object):
         self._index = 0
 
     def parse(self, expression):
-        cached = self._CACHE.get(expression)
-        if cached is not None:
-            return cached
+        try:
+            return self._CACHE[expression]
+        except KeyError:
+            pass
         parsed_result = self._do_parse(expression)
+        if len(self._CACHE) >= self._MAX_SIZE:
+            try:
+                del self._CACHE[next(iter(self._CACHE))]
+            except (KeyError, StopIteration, RuntimeError):
+                # KeyError - Another thread else already deleted the key.
+                # RuntimeError - Another modified the cache.
+                # StopIteration - (Unlikely) Cache is empty.
+                #
+                # If we encounter an error we should NOT be adding to the
+                # cache.  To ensure we do not exceed self._MAX_SIZE, we
+                # can only add to the cache if we successfully removed
+                # an element from the cache, otherwise this can grow
+                # unbounded.
+                return parsed_result
         self._CACHE[expression] = parsed_result
-        if len(self._CACHE) > self._MAX_SIZE:
-            self._free_cache_entries()
         return parsed_result
 
     def _do_parse(self, expression):
@@ -487,10 +498,6 @@ class Parser(object):
                                               actual_type)
         raise exceptions.ParseError(
             lex_position, actual_value, actual_type, message)
-
-    def _free_cache_entries(self):
-        oldest_key = next(iter(self._CACHE))
-        del self._CACHE[oldest_key]
 
     @classmethod
     def purge(cls):

--- a/jmespath/parser.py
+++ b/jmespath/parser.py
@@ -73,7 +73,7 @@ class Parser(object):
     # The _MAX_SIZE most recent expressions are cached in
     # _CACHE dict.
     _CACHE = {}
-    _MAX_SIZE = 128
+    _MAX_SIZE = 512
 
     def __init__(self, lookahead=2):
         self.tokenizer = None
@@ -489,8 +489,8 @@ class Parser(object):
             lex_position, actual_value, actual_type, message)
 
     def _free_cache_entries(self):
-        for key in random.sample(list(self._CACHE.keys()), int(self._MAX_SIZE / 2)):
-            self._CACHE.pop(key, None)
+        oldest_key = next(iter(self._CACHE))
+        del self._CACHE[oldest_key]
 
     @classmethod
     def purge(cls):


### PR DESCRIPTION
## JMESPath Cache Fixes

This PR attempts to address two issues with the existing cache implementation. The first is an issue with how we choose static sizing for cache eviction which means we may not clear the cache back to a reasonable size without multiple calls.
The second is a race condition in the cache that appeared in Python 3.10+, causing cache eviction to fail with `Sample larger than population or is negative`.

### Cache Free Size Issues
Currently the cache performs `self._MAX_SIZE/2` (64) evictions on random keys in the cache when the size exceeds `self._MAX_SIZE` (128). The issue with this is in highly parallelized run times, the cache can significantly exceed the size limit. The next invocation on `parse()` only clears a static amount, which means evicting from the cache may take several cycles.

### Cache Eviction Race Condition

When `parse()` is called in a highly parallelized environment, it's possible for two invocations to hit the cache clear at the same time. If some clears finish before another begins, we can invoke `random.sample` with a `k` (in this case 64) larger than our cache. That results in a [ValueError](https://github.com/python/cpython/blob/726e8e8defc487c55ade9f6015aaf2bae6cec3f3/Lib/random.py#L435-L436) because we're requesting more samples than we have keys.

## Updated Fix (Post-discussion)
This PR now changes the MAX_SIZE to 512 allowing for a larger cache to avoid needing eviction in the common case. It also switches the cache to a simpler FIFO implementation that will only affect one entry at a time. This should have minimal impact on performance from initial testing and ensure we don't hit a race condition without the lock. In the event that an entry cannot be evicted due another thread removing the entry, it will be treated as a no-op.