### PR TITLE
1.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Next Release (TBD)
 ==================
 
+* No changes yet.
+
+
+1.1.0
+=====
+
 * Fix concurrency issue with cache
   (`pr #335 <https://github.com/jmespath/jmespath.py/pull/335>`__)
 * Added support for Python 3.12-3.14 (`pr #331 <https://github.com/jmespath/jmespath.py/pull/331>`__)

--- a/jmespath/__init__.py
+++ b/jmespath/__init__.py
@@ -1,7 +1,7 @@
 from jmespath import parser
 from jmespath.visitor import Options
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'
 
 
 def compile(expression):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='jmespath',
-    version='1.0.1',
+    version='1.1.0',
     description='JSON Matching Expressions',
     long_description=io.open('README.rst', encoding='utf-8').read(),
     author='James Saryerwinnie',


### PR DESCRIPTION
1.1.0
=====

* Fix concurrency issue with cache (#335)
* Added support for Python 3.12-3.14 (#331)
* Removed support for Python 3.7-3.8 (#335)

## New Contributors
* @iloveitaly made their first contribution in https://github.com/jmespath/jmespath.py/pull/331
* @mondeja made their first contribution in https://github.com/jmespath/jmespath.py/pull/289