### PR TITLE
Fix TypeError on ordering comparison between string and number

### DIFF
--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -151,9 +151,10 @@ class TreeInterpreter(Visitor):
             # will yield a None value.
             left = self.visit(node['children'][0], value)
             right = self.visit(node['children'][1], value)
-            num_types = (int, float)
-            if not (_is_comparable(left) and
-                    _is_comparable(right)):
+            if not ((_is_actual_number(left) and
+                     _is_actual_number(right)) or
+                    (isinstance(left, string_type) and
+                     isinstance(right, string_type))):
                 return None
             return comparator_func(left, right)
 


### PR DESCRIPTION
Ordering comparators (`<`, `<=`, `>`, `>=`) crash with `TypeError` when comparing a string to a number:

```python
>>> jmespath.search('[?a < b]', [{"a": "foo", "b": 5}])
TypeError: '<' not supported between instances of 'str' and 'int'
```

Per the JMESPath spec, ordering comparisons on incompatible types should return `null`.

The bug is in `_is_comparable()` — it returns `True` for numbers *or* strings independently. When one operand is a string and the other is a number, both pass the individual check, but `operator.lt("foo", 5)` raises `TypeError` in Python 3.

The fix requires both operands to be the *same* comparable type (both numbers or both strings). This also removes the unused `num_types` variable that was left over from before string comparisons were added.
