### PR TITLE
Type-check extra arguments to variadic functions

### DIFF
--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -96,6 +96,12 @@ class Functions(metaclass=FunctionRegistry):
             if allowed_types:
                 self._type_check_single(actual[i], allowed_types,
                                         function_name)
+        if signature and signature[-1].get('variadic'):
+            allowed_types = signature[-1]['types']
+            if allowed_types:
+                for i in range(len(signature), len(actual)):
+                    self._type_check_single(actual[i], allowed_types,
+                                            function_name)
 
     def _type_check_single(self, current, types, function_name):
         # Type checking involves checking the top level type,


### PR DESCRIPTION
`_type_check` only validates the first N arguments where N is the length of the function signature. For variadic functions like `merge()`, the signature has a single entry with `variadic: True`, so only the **first** argument is type-checked. All extra arguments bypass validation entirely.

```python
>>> jmespath.search('merge(`{"a":1}`, `"not_a_dict"`)', {})
# Expected: JMESPathTypeError (string is not an object)
# Actual: ValueError: dictionary update sequence element #0 has length 1
```

The fix adds a second loop after the normal signature check that validates the extra variadic arguments against the last signature entry's type constraints.
