### PR TITLE
Update supported Python versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t", "3.15-dev"]
 
     steps:
     - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
@@ -23,8 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install pip==25.1.0
-        pip install -r requirements.txt
+        python -m pip install -r requirements.txt
         python -m pip install .
     - name: Test with pytest
       run: |

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,6 @@ setup(
         'Programming Language :: Python :: 3.14',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
+        'Programming Language :: Python :: Free Threading :: 2 - Beta',
     ],
 )


### PR DESCRIPTION
This PR adds testing for Python 3.14t (free threaded build), Python 3.15 which [entered beta yesterday](https://blog.python.org/2026/05/python-3150-beta-1/), and drops support for Python 3.9 now that it's been dropped from Boto3/Botocore.