### PR TITLE
Return false for contains(string, non-string) instead of raising TypeError

### DIFF
--- a/jmespath/functions.py
+++ b/jmespath/functions.py
@@ -212,6 +212,14 @@ class Functions(metaclass=FunctionRegistry):
 
     @signature({'types': ['array', 'string']}, {'types': []})
     def _func_contains(self, subject, search):
+        # A non-string can never be a substring of a string. The array case
+        # already returns False for a non-matching search of any type, but
+        # ``search in subject`` raises TypeError when subject is a string and
+        # search is not, so guard it explicitly (spec: contains('foobar', 123)
+        # -> false).
+        if (isinstance(subject, STRING_TYPE)
+                and not isinstance(search, STRING_TYPE)):
+            return False
         return search in subject
 
     @signature({'types': ['string', 'array', 'object']})

--- a/tests/compliance/functions.json
+++ b/tests/compliance/functions.json
@@ -116,6 +116,18 @@
       "result": false
     },
     {
+      "expression": "contains('foobar', `123`)",
+      "result": false
+    },
+    {
+      "expression": "contains('foobar', `true`)",
+      "result": false
+    },
+    {
+      "expression": "contains('foobar', `null`)",
+      "result": false
+    },
+    {
       "expression": "contains(`false`, 'd')",
       "error": "invalid-type"
     },


### PR DESCRIPTION
## Summary

`contains()` with a **string** subject and a **non-string** search raises an uncaught `TypeError` instead of returning `false`:

```python
import jmespath
jmespath.search("contains(@, `123`)", "foobar")
# TypeError: 'in <string>' requires string as left operand, not int
```

This contradicts the JMESPath spec, which defines `contains('foobar', `123`) → false`. It affects any non-string search against a string subject — number, boolean, null, array, or object.

The **array** case already returns `false` for a type-mismatched search of any type (`contains(`[1,2,3]`, `false`) → false`), because Python's `in` on a list accepts any right-hand type. Only the string path was inconsistent, since `123 in "foobar"` raises.

## Cause

`Functions._func_contains` was simply:

```python
@signature({'types': ['array', 'string']}, {'types': []})
def _func_contains(self, subject, search):
    return search in subject
```

The signature permits a `search` of any type, but `search in subject` raises `TypeError` when `subject` is a string and `search` is not.

## Fix

Guard the membership test: when the subject is a string and the search is not, return `false` (a non-string can never be a substring of a string). This brings the string path in line with the array path and the spec.

## Verification

- Added compliance cases for number, boolean and null searches against a string subject (`tests/compliance/functions.json`), each expecting `false`. They fail with `TypeError` before the fix and pass after (confirmed via `git stash`).
- String-in-string and all array-membership behavior is unchanged.
- Full suite: **994 passed, 1 skipped** (was 991 + 1 skipped).

This pull request was prepared with the assistance of AI, under my direction and review.
