### PR TITLE
Include test helpers in source distributions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,9 @@
 Next Release (TBD)
 ==================
 
-* No changes yet.
+* Include ``tests/__init__.py`` in source distributions so the bundled test
+  suite can import its shared helpers (`issue #341
+  <https://github.com/jmespath/jmespath.py/issues/341>`__).
 
 
 1.1.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 include LICENSE
+include tests/__init__.py


### PR DESCRIPTION
Fixes #341.

The source distribution already includes the test modules, but setuptools does not automatically include `tests/__init__.py`. As a result, running the bundled tests fails while importing the shared `OrderedDict` and `json` helpers from `tests`.

This explicitly includes the package initializer in `MANIFEST.in` and documents the packaging fix in the changelog.

Validation:
- `python -m pytest tests -q` — 991 passed, 1 skipped
- built the sdist with `uv build --sdist` and verified it contains `jmespath-1.1.0/tests/__init__.py`