### PR TITLE
Include full tests/ tree in sdist via MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 include LICENSE
+recursive-include tests *


### PR DESCRIPTION
## Summary

Fixes #341.

`setuptools`' default sdist file-finder only auto-includes files matching the `tests/test*.py` glob. It silently drops `tests/__init__.py`, `tests/compliance/*.json`, and `tests/legacy/*.json`, none of which match that pattern. That's why the sdist published for 1.1.0 is missing `tests/__init__.py`: `test_compliance.py` does `from tests import OrderedDict`, which fails once the sdist is extracted and tests are run against it, exactly as reported in #341.

`MANIFEST.in` never listed the `tests/` directory at all — the previously-"working" inclusion of `tests/test_*.py` was always just `setuptools`' default optional glob, which happens to miss everything else under `tests/`.

The fix adds one line to `MANIFEST.in` to explicitly include the entire `tests/` tree (source files + JSON fixtures + subdirectories), rather than relying on the incomplete default heuristic.

## Test plan

Built and ran the actual sdist end-to-end locally:

- `git diff` before/after this change: before, `python setup.py egg_info`'s generated `SOURCES.txt` lists `tests/test_*.py` but omits `tests/__init__.py`, `tests/compliance/*.json`, and `tests/legacy/*.json`.
- After the `MANIFEST.in` change: `python -m build --sdist` produces a tarball whose `tests/` directory now contains all of `__init__.py`, `compliance/*.json` (16 files), and `legacy/literal.json`, matching the full contents of the repo's `tests/` directory.
- Extracted the built sdist into a clean directory, `pip install`ed it into a fresh venv, and ran `pytest` from `tests/` against the installed package: **991 passed, 1 skipped**, with no import errors (previously this would fail at collection with `ImportError: cannot import name 'OrderedDict' from 'tests'`, per the traceback in #341).

Platform tested: Windows 11 (Python 3.14).