### PR TITLE
fix: include tests/__init__.py in sdist (resolves #341)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 include LICENSE
+recursive-include tests *.py


### PR DESCRIPTION
## Summary

Resolves #341.

`MANIFEST.in` only listed `README.rst` and `LICENSE`. Because `setup.py` uses
`find_packages(exclude=['tests'])`, setuptools does **not** treat `tests` as a
package and therefore drops the package marker `tests/__init__.py` from the
source distribution — while still shipping the loose `tests/test_*.py` modules.

A downstream build that imports from the package (e.g. `tests/test_compliance.py`
doing `from tests import OrderedDict`) then fails with:

```
ImportError: cannot import name 'OrderedDict' from 'tests' (unknown location)
```

Adding `recursive-include tests *.py` makes the sdist carry the `__init__.py`
package marker alongside the test modules.

## Verification (no-run-no-claim)

Built the sdist locally with the repo's `setup.py sdist` (setuptools 83.0.0,
Python 3.13) before and after the change:

- **Before:** sdist contains `tests/test_*.py` (7 files) but **no** `tests/__init__.py`.
- **After:** sdist contains `tests/__init__.py` **and** all 7 `tests/test_*.py` modules.

## Scope

Packaging/`MANIFEST.in` only. No runtime or library code changed; the installed
wheel is unaffected (tests were already excluded from the wheel).

---
*AI-assisted contribution: the root-cause analysis and patch were drafted with an AI coding assistant and the author reviewed and verified the sdist build before opening this PR.*