### PR TITLE
Return null when a slice step is 0

### DIFF
--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -218,8 +218,11 @@ class TreeInterpreter(Visitor):
     def visit_slice(self, node, value):
         if not isinstance(value, list):
             return None
-        s = slice(*node['children'])
-        return value[s]
+        try:
+            s = slice(*node['children'])
+            return value[s]
+        except ValueError:
+            return None
 
     def visit_key_val_pair(self, node, value):
         return self.visit(node['children'][0], value)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -62,3 +62,6 @@ class TestPythonSpecificCases(unittest.TestCase):
         result = decimal.Decimal('3')
         self.assertEqual(jmespath.search('[?a >= `1`].a', [{'a': result}]),
                          [result])
+
+    def test_zero_step_slice_returns_none(self):
+        self.assertIsNone(jmespath.search('[::0]', [1, 2, 3]))


### PR DESCRIPTION
`[::0]` raised `ValueError: slice step cannot be zero`. Other failed projections (slicing a non-array) already return null.