### PR TITLE
Fix reference cycle in Visitor's method cache

### DIFF
--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -88,10 +88,17 @@ class Visitor(object):
         node_type = node['type']
         method = self._method_cache.get(node_type)
         if method is None:
+            # Looking this up on the class instead of on self means we
+            # cache a plain function rather than a bound method.  A bound
+            # method holds a reference back to the instance it's bound to,
+            # so stashing one in an attribute of that same instance
+            # (self._method_cache) creates a reference cycle, and every
+            # single instance then needs a cyclic GC pass to be collected
+            # instead of going away as soon as its refcount hits zero.
             method = getattr(
-                self, 'visit_%s' % node['type'], self.default_visit)
+                type(self), 'visit_%s' % node['type'], type(self).default_visit)
             self._method_cache[node_type] = method
-        return method(node, *args, **kwargs)
+        return method(self, node, *args, **kwargs)
 
     def default_visit(self, node, *args, **kwargs):
         raise NotImplementedError("default_visit")

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+import gc
+import weakref
+
+from tests import unittest
+
+import jmespath
+from jmespath import visitor
+
+
+class TestVisitorMethodCache(unittest.TestCase):
+    def test_method_cache_does_not_create_reference_cycle(self):
+        # Visitor.visit() caches the resolved visit_* method on
+        # self._method_cache.  If that cache stores a bound method, the
+        # instance ends up holding a reference to itself
+        # (self -> _method_cache -> bound method -> self), and a whole
+        # TreeInterpreter (one gets built on every ParsedResult.search()
+        # call) can then only be reclaimed by the cyclic garbage
+        # collector instead of going away as soon as its refcount drops
+        # to zero. Under a heavy search workload that adds up to a lot
+        # of avoidable GC churn.
+        gc.disable()
+        try:
+            expression = jmespath.compile('a.b.c')
+            created = []
+            original_init = visitor.TreeInterpreter.__init__
+
+            def spy_init(self, *args, **kwargs):
+                original_init(self, *args, **kwargs)
+                created.append(weakref.ref(self))
+
+            visitor.TreeInterpreter.__init__ = spy_init
+            try:
+                result = expression.search({'a': {'b': {'c': 1}}})
+            finally:
+                visitor.TreeInterpreter.__init__ = original_init
+
+            self.assertEqual(result, 1)
+            self.assertEqual(len(created), 1)
+            # No gc.collect() here on purpose: if there were still a
+            # reference cycle, the interpreter would still be alive at
+            # this point even though nothing outside this test holds a
+            # reference to it any more.
+            self.assertIsNone(
+                created[0](),
+                "TreeInterpreter survived past its last external "
+                "reference without a gc.collect(), which means its "
+                "method cache is holding a reference cycle again.")
+        finally:
+            gc.enable()
+
+    def test_visit_still_dispatches_correctly_after_caching(self):
+        # The fix changes *what* gets stored in _method_cache (a plain
+        # function looked up on the class instead of a bound method on
+        # the instance), so repeat this a few times to make sure
+        # dispatch through the cached entry still reaches the right
+        # subclass-specific visit_* implementation.
+        for _ in range(3):
+            self.assertEqual(
+                jmespath.search('a.b.c', {'a': {'b': {'c': 42}}}), 42)
+        self.assertEqual(
+            jmespath.search('foo[*].bar', {'foo': [{'bar': 1}, {'bar': 2}]}),
+            [1, 2])


### PR DESCRIPTION
Follows up on #291. Visitor.visit() resolves the right visit_* method for a node type and stashes it in self._method_cache so the next node of the same type skips the getattr lookup. The lookup goes through self, though, which means what actually gets cached is a bound method, and a bound method carries a reference back to the instance it's bound to. So every TreeInterpreter ends up holding a reference to itself through its own cache, and since TreeInterpreter.search() builds a fresh interpreter on every call, that's a steady source of objects that can only be reclaimed by a cyclic GC pass instead of going away the moment their refcount hits zero. jamesls confirmed this with tracemalloc on the original issue and pointed straight at _method_cache as the main source of the extra allocations.

The fix looks the method up on type(self) instead, which gives back a plain function rather than a bound one, and calls it as method(self, node, ...). Dispatch behaves exactly the same, including for subclasses that override visit_* or default_visit, but nothing in the cache points back at an instance any more.

Added a test that spies on TreeInterpreter.__init__ to grab a weakref, runs one search, and checks the interpreter is already gone with gc disabled and no explicit collect() call. That only holds if nothing is keeping it alive through a cycle, so it fails on the current code and passes with the fix.

Full test suite passes locally (993 tests, 1 pre-existing skip, both unaffected by this change).