### PR TITLE
Preserve boolean distinctions in nested JSON equality

### DIFF
--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -6,16 +6,24 @@ from numbers import Number
 
 
 def _equals(x, y):
-    if _is_special_number_case(x, y):
-        return False
-    elif isinstance(x, list) and isinstance(y, list):
-        return len(x) == len(y) and all(
-            _equals(a, b) for a, b in zip(x, y))
-    elif isinstance(x, dict) and isinstance(y, dict):
-        return x.keys() == y.keys() and all(
-            _equals(x[key], y[key]) for key in x)
-    else:
-        return x == y
+    pending = [(x, y)]
+    while pending:
+        x, y = pending.pop()
+        if _is_special_number_case(x, y):
+            return False
+        elif isinstance(x, list) and isinstance(y, list):
+            if len(x) != len(y):
+                return False
+            if x is not y:
+                pending.extend(zip(reversed(x), reversed(y)))
+        elif isinstance(x, dict) and isinstance(y, dict):
+            if x.keys() != y.keys():
+                return False
+            if x is not y:
+                pending.extend((x[key], y[key]) for key in reversed(x))
+        elif not (x == y):
+            return False
+    return True
 
 
 def _is_special_number_case(x, y):

--- a/jmespath/visitor.py
+++ b/jmespath/visitor.py
@@ -8,6 +8,12 @@ from numbers import Number
 def _equals(x, y):
     if _is_special_number_case(x, y):
         return False
+    elif isinstance(x, list) and isinstance(y, list):
+        return len(x) == len(y) and all(
+            _equals(a, b) for a, b in zip(x, y))
+    elif isinstance(x, dict) and isinstance(y, dict):
+        return x.keys() == y.keys() and all(
+            _equals(x[key], y[key]) for key in x)
     else:
         return x == y
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -62,3 +62,37 @@ class TestPythonSpecificCases(unittest.TestCase):
         result = decimal.Decimal('3')
         self.assertEqual(jmespath.search('[?a >= `1`].a', [{'a': result}]),
                          [result])
+
+
+class TestNestedEquality(unittest.TestCase):
+    def test_nested_booleans_are_not_numbers(self):
+        for left, right in [
+                ([True], [1]),
+                ([False], [0]),
+                ({'value': True}, {'value': 1}),
+                ({'value': [False]}, {'value': [0]}),
+                ([{'value': True}], [{'value': 1.0}])]:
+            for a, b in [(left, right), (right, left)]:
+                data = {'a': a, 'b': b}
+                self.assertFalse(jmespath.search('a == b', data))
+                self.assertTrue(jmespath.search('a != b', data))
+
+    def test_nested_equality_preserves_json_semantics(self):
+        cases = [
+            ([1], [1.0], True),
+            ({'a': [True, 1]}, {'a': [True, 1.0]}, True),
+            ({'a': 1, 'b': 2}, {'b': 2, 'a': 1}, True),
+            ([1], [1, 2], False),
+            ({'a': None}, {'b': None}, False),
+            ([], {}, False),
+            ([], [], True),
+            ({}, {}, True),
+        ]
+        for a, b, expected in cases:
+            self.assertEqual(jmespath.search('a == b', {'a': a, 'b': b}),
+                             expected)
+
+    def test_filter_rejects_nested_boolean_number_matches(self):
+        data = [{'value': [True]}, {'value': [1]}, {'value': [1.0]}]
+        self.assertEqual(jmespath.search('[?value == `[1]`]', data),
+                         data[1:])

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,5 +1,6 @@
 import sys
 import decimal
+import json
 from tests import unittest, OrderedDict
 
 import jmespath
@@ -96,3 +97,18 @@ class TestNestedEquality(unittest.TestCase):
         data = [{'value': [True]}, {'value': [1]}, {'value': [1.0]}]
         self.assertEqual(jmespath.search('[?value == `[1]`]', data),
                          data[1:])
+
+
+    def test_deeply_nested_json_equality(self):
+        for opening, closing in [('[', ']'), ('{"value":', '}')]:
+            for left, right, expected in [
+                    ('1', '1.0', True),
+                    ('true', '1', False),
+                    ('1', '2', False),
+                    ('[]', '{}', False)]:
+                a = json.loads(opening * 600 + left + closing * 600)
+                b = json.loads(opening * 600 + right + closing * 600)
+                self.assertIsNot(a, b)
+                data = {'a': a, 'b': b}
+                self.assertEqual(jmespath.search('a == b', data), expected)
+                self.assertEqual(jmespath.search('a != b', data), not expected)


### PR DESCRIPTION
Nested equality currently delegates to Python container equality, so `[true] == [1]` returns true even though the corresponding JMESPath scalar comparison is false. This also includes incorrect records in filters on nested values.

Compare array elements and object values with an explicit work stack and JMESPath scalar equality. This preserves boolean/number distinctions without adding Python recursion frames. Numeric equality, object key ordering, differing lengths/keys, empty containers, and identical-object fast paths remain supported.

Validation on macOS/Python 3.12.13:
- Original implementation fails the two new nested comparison/filter regressions.
- `python -m pytest tests -q`: 995 passed, 1 skipped.
- Independently parsed depth-600 JSON arrays and objects pass equality, boolean/number mismatch, unequal-value, and leaf-shape checks without changing the recursion limit.
- Public API filtering selects numeric records and excludes the corresponding boolean record.

The full platform/Python-version matrix was not run locally. The work stack uses memory proportional to queued structural pairs.

AI disclosure: OpenAI Codex assisted with the implementation, tests, and description. The reported checks were executed locally.
